### PR TITLE
:sparkles: TagInput Component

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,3 +1,8 @@
+export {};
+
 declare global {
-  type ABC = string;
+  type Option<T> = {
+    label: string;
+    value: T;
+  };
 }

--- a/src/Layout/Box.styled.ts
+++ b/src/Layout/Box.styled.ts
@@ -21,7 +21,7 @@ export const commonBoxStyle = css<BoxProps>`
     justifyContent = 'Start',
     alignItems = 'Start',
     gap = 0,
-    $wrap = false,
+    flexWrap = false,
     padding,
     paddingTop,
     paddingBottom,
@@ -34,7 +34,7 @@ export const commonBoxStyle = css<BoxProps>`
       justify-content: ${JUSTIFY_CONTENT[justifyContent]};
       align-items: ${ALIGN_ITEMS[alignItems]};
       gap: ${gap}px;
-      flex-wrap: ${$wrap ? 'wrap' : 'nowrap'};
+      flex-wrap: ${flexWrap ? 'wrap' : 'nowrap'};
       ${[typeof padding === 'number' ? `padding: ${padding}px;` : '']}
       ${[
         typeof paddingLeft === 'number'

--- a/src/Layout/Box.styled.ts
+++ b/src/Layout/Box.styled.ts
@@ -21,7 +21,7 @@ export const commonBoxStyle = css<BoxProps>`
     justifyContent = 'Start',
     alignItems = 'Start',
     gap = 0,
-    wrap = false,
+    $wrap = false,
     padding,
     paddingTop,
     paddingBottom,
@@ -33,8 +33,8 @@ export const commonBoxStyle = css<BoxProps>`
       flex-direction: ${direction};
       justify-content: ${JUSTIFY_CONTENT[justifyContent]};
       align-items: ${ALIGN_ITEMS[alignItems]};
-      gap: ${`${gap}px`};
-      wrap: ${wrap ? 'wrap' : 'nowrap'};
+      gap: ${gap}px;
+      flex-wrap: ${$wrap ? 'wrap' : 'nowrap'};
       ${[typeof padding === 'number' ? `padding: ${padding}px;` : '']}
       ${[
         typeof paddingLeft === 'number'

--- a/src/Layout/Box.types.ts
+++ b/src/Layout/Box.types.ts
@@ -24,7 +24,7 @@ export type BoxProps = HTMLAttributes<HTMLDivElement> & {
    * @uxpinpropname Align
    * */
   alignItems?: 'Start' | 'Center' | 'End';
-  $wrap?: boolean;
+  flexWrap?: boolean;
   gap?: Spacing[keyof typeof SPACING];
   padding?: Spacing[keyof typeof SPACING];
   paddingTop?: Spacing[keyof typeof SPACING];

--- a/src/Layout/Box.types.ts
+++ b/src/Layout/Box.types.ts
@@ -24,7 +24,7 @@ export type BoxProps = HTMLAttributes<HTMLDivElement> & {
    * @uxpinpropname Align
    * */
   alignItems?: 'Start' | 'Center' | 'End';
-  wrap?: boolean;
+  $wrap?: boolean;
   gap?: Spacing[keyof typeof SPACING];
   padding?: Spacing[keyof typeof SPACING];
   paddingTop?: Spacing[keyof typeof SPACING];

--- a/src/TagInput/Tag/Tag.stories.tsx
+++ b/src/TagInput/Tag/Tag.stories.tsx
@@ -1,0 +1,33 @@
+import Tag from './Tag';
+import { Story, Meta } from '@storybook/react';
+import { TagProps } from './Tag.types';
+
+export default {
+  title: 'Components/TagInput/Tag',
+  component: Tag,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const TAG: Option<string> = { label: 'LABEL', value: 'value1' };
+
+const Template: Story<TagProps> = ({ ...args }) => {
+  return <Tag {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  tag: { ...TAG, status: 'normal' },
+};
+
+export const Error = Template.bind({});
+Error.args = {
+  tag: { ...TAG, status: 'error' },
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  tag: { ...TAG, status: 'disabled' },
+};

--- a/src/TagInput/Tag/Tag.styled.ts
+++ b/src/TagInput/Tag/Tag.styled.ts
@@ -1,0 +1,65 @@
+import styled, { css } from 'styled-components';
+import { TagStatus } from './Tag.types';
+
+export const Container = styled.div<{ status: TagStatus }>`
+  ${({ theme, status }) =>
+    css`
+      box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      width: fit-content;
+      column-gap: ${theme.spacing.spacing2}px;
+      border-radius: 4px;
+      padding: ${theme.spacing.spacing0}px ${theme.spacing.spacing4}px;
+      & svg {
+        cursor: pointer;
+      }
+      ${status === 'normal' &&
+      css`
+        & {
+          background-color: ${theme.colors.N200};
+          svg {
+            color: ${theme.colors.N800};
+          }
+        }
+      `}
+      ${status === 'error' &&
+      css`
+        & {
+          background-color: ${theme.colors.R100};
+          svg {
+            color: ${theme.colors.N600};
+          }
+        }
+      `}
+      ${status === 'disabled' &&
+      css`
+        & {
+          background-color: ${theme.colors.N100};
+          svg {
+            cursor: default;
+            color: ${theme.colors.N500};
+          }
+        }
+      `}
+    `}
+`;
+
+export const Label = styled.span<{ status: TagStatus }>`
+  ${({ theme, status }) =>
+    css`
+      ${theme.typography.P100};
+      ${status === 'normal' &&
+      css`
+        color: ${theme.colors.N800};
+      `}
+      ${status === 'error' &&
+      css`
+        color: ${theme.colors.N800};
+      `}
+      ${status === 'disabled' &&
+      css`
+        color: ${theme.colors.N500};
+      `}
+    `}
+`;

--- a/src/TagInput/Tag/Tag.styled.ts
+++ b/src/TagInput/Tag/Tag.styled.ts
@@ -1,16 +1,13 @@
 import styled, { css } from 'styled-components';
+import { Box } from '../../Layout';
 import { TagStatus } from './Tag.types';
 
-export const Container = styled.div<{ status: TagStatus }>`
+export const Container = styled(Box)<{ status: TagStatus }>`
   ${({ theme, status }) =>
     css`
       box-sizing: border-box;
-      display: flex;
-      align-items: center;
       width: fit-content;
-      column-gap: ${theme.spacing.spacing2}px;
       border-radius: 4px;
-      padding: ${theme.spacing.spacing0}px ${theme.spacing.spacing4}px;
       & svg {
         cursor: pointer;
       }

--- a/src/TagInput/Tag/Tag.tsx
+++ b/src/TagInput/Tag/Tag.tsx
@@ -4,7 +4,14 @@ import ActionSmallCrossIcon from '../../parte-icons/Icons/ActionSmallCrossIcon';
 
 function Tag({ tag, onRemove }: TagProps) {
   return (
-    <Styled.Container status={tag.status} tabIndex={0}>
+    <Styled.Container
+      status={tag.status}
+      tabIndex={0}
+      gap={2}
+      paddingRight={4}
+      paddingLeft={4}
+      alignItems="Center"
+    >
       <Styled.Label status={tag.status}>{tag.label}</Styled.Label>
       <ActionSmallCrossIcon
         color="danger"

--- a/src/TagInput/Tag/Tag.tsx
+++ b/src/TagInput/Tag/Tag.tsx
@@ -1,0 +1,18 @@
+import * as Styled from './Tag.styled';
+import { TagProps } from './Tag.types';
+import ActionSmallCrossIcon from '../../parte-icons/Icons/ActionSmallCrossIcon';
+
+function Tag({ tag, onRemove }: TagProps) {
+  return (
+    <Styled.Container status={tag.status} tabIndex={0}>
+      <Styled.Label status={tag.status}>{tag.label}</Styled.Label>
+      <ActionSmallCrossIcon
+        color="danger"
+        size={12}
+        onClick={() => onRemove(tag.value)}
+      />
+    </Styled.Container>
+  );
+}
+
+export default Tag;

--- a/src/TagInput/Tag/Tag.types.ts
+++ b/src/TagInput/Tag/Tag.types.ts
@@ -1,0 +1,10 @@
+export type TagStatus = 'normal' | 'disabled' | 'error';
+
+export type TagOption = Option<string> & {
+  status: TagStatus;
+};
+
+export type TagProps = {
+  tag: TagOption;
+  onRemove: (value: string) => void;
+};

--- a/src/TagInput/Tag/index.ts
+++ b/src/TagInput/Tag/index.ts
@@ -1,0 +1,1 @@
+export { default as Tag } from './Tag';

--- a/src/TagInput/TagInput.stories.tsx
+++ b/src/TagInput/TagInput.stories.tsx
@@ -1,0 +1,64 @@
+import TagInput from './TagInput';
+import { Story, Meta } from '@storybook/react';
+import { TagInputProps } from './TagInput.types';
+import ActionCrossIcon from '../parte-icons/Icons/ActionCrossIcon';
+import InterfaceCaretDownIcon from '../parte-icons/Icons/InterfaceCaretDownIcon';
+import { useState } from 'react';
+import { TagOption } from './Tag/Tag.types';
+
+export default {
+  title: 'Components/TagInput',
+  component: TagInput,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const OPTION_LIST: TagOption[] = [
+  { label: 'label1', value: '1', status: 'normal' },
+  { label: 'label2', value: '2', status: 'error' },
+  { label: 'label3', value: '3', status: 'disabled' },
+];
+
+const Template: Story<TagInputProps> = ({ ...args }) => {
+  const [values, setValues] = useState<TagOption[]>(OPTION_LIST);
+
+  const onAdd = (label: string) => {
+    setValues((props) => [...props, { label, value: label, status: 'normal' }]);
+  };
+
+  const onRemove = (value: string) => {
+    const filteredList = values.filter((option) => option.value !== value);
+    setValues(filteredList);
+  };
+
+  return (
+    <TagInput
+      {...args}
+      rightSlot={
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <ActionCrossIcon
+            size={12}
+            color="muted"
+            onClick={() => setValues([])}
+          />
+          <InterfaceCaretDownIcon size={12} color="muted" />
+        </div>
+      }
+      placeholder="Placeholder"
+      values={values}
+      onRemove={onRemove}
+      onAdd={onAdd}
+      required
+    />
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  disabled: true,
+};

--- a/src/TagInput/TagInput.styled.ts
+++ b/src/TagInput/TagInput.styled.ts
@@ -1,0 +1,139 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+`;
+
+export const InputWrapper = styled.div<{
+  focused: boolean;
+  error?: boolean;
+  disabled?: boolean;
+  hover?: boolean;
+}>`
+  ${({ theme, focused, disabled, error, hover }) => css`
+    box-sizing: border-box;
+    display: flex;
+    overflow: hidden;
+    border: 1px solid ${theme.colorBorderDefault};
+    border-radius: 4px;
+    ${hover &&
+    css`
+      border: 1px solid ${theme.colorBorderHover};
+      background: ${theme.colorBackgroundHover};
+    `}
+    ${focused &&
+    css`
+       {
+        border: 1px solid ${theme.colorBorderFocused};
+        ${theme.commonStyles.outline}
+      }
+    `}
+    ${disabled &&
+    css`
+       {
+        background-color: ${theme.colorBackgroundDisabled};
+        border: 1px solid ${theme.colorBorderDisabled};
+      }
+    `}
+    ${error &&
+    css`
+      &,
+      &:hover,
+      &:focus {
+        border: 1px solid ${theme.colors.R400};
+      }
+    `}
+  `}
+`;
+
+export const LabelWrapper = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: flex-start;
+    column-gap: ${theme.spacing.spacing2}px;
+    margin-bottom: ${theme.spacing.spacing4}px;
+  `}
+`;
+
+export const Required = styled.label`
+  ${({ theme }) => css`
+    ${theme.typography.C200}
+    color: ${theme.colors.R400};
+  `}
+`;
+
+export const Label = styled.label`
+  ${({ theme }) => css`
+    ${theme.typography.H400}
+    color: ${theme.colorHeading};
+  `}
+`;
+
+export const Description = styled.p`
+  ${({ theme }) => css`
+    ${theme.typography.P100}
+    color: ${theme.colorParagraph};
+    margin-bottom: ${theme.spacing.spacing8}px;
+  `}
+`;
+
+export const RightIconContainer = styled.div<{ disabled: boolean }>`
+  ${({ theme, disabled }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: ${theme.spacing.spacing10}px;
+    svg {
+      ${disabled &&
+      css`
+        color: ${theme.colorTextDisabled};
+      `};
+    }
+  `}
+`;
+
+export const ErrorText = styled.p`
+  ${({ theme }) => css`
+    ${theme.typography.P100};
+    color: ${theme.colors.R400};
+    margin-top: ${theme.spacing.spacing2}px;
+  `}
+`;
+
+export const Input = styled.input`
+  ${({ theme }) => css`
+    outline: none;
+    border: none;
+    box-sizing: border-box;
+    flex: 1;
+    padding: ${theme.spacing.spacing0}px;
+    background-color: ${theme.colorBackgroundDefault};
+    color: ${theme.colorParagraph};
+    ${theme.typography.P100}
+
+    ::placeholder {
+      color: ${theme.colorTextPlaceholderDefault};
+    }
+
+    &:hover {
+      ::placeholder {
+        color: ${theme.colorTextPlaceholderHover};
+      }
+    }
+    &:focus {
+      ::placeholder {
+        color: ${theme.colorTextPlaceholderFocused};
+      }
+    }
+    &:disabled {
+      color: ${theme.colorTextDisabled};
+      ::placeholder {
+        color: ${theme.colorTextPlaceholderDisabled};
+      }
+      background-color: ${theme.colorBackgroundDisabled};
+    }
+  `}
+`;

--- a/src/TagInput/TagInput.tsx
+++ b/src/TagInput/TagInput.tsx
@@ -1,0 +1,152 @@
+import {
+  FocusEvent,
+  forwardRef,
+  KeyboardEvent,
+  useMemo,
+  useState,
+  ChangeEvent,
+} from 'react';
+import * as Styled from './TagInput.styled';
+import { Box } from '../Layout';
+import { v4 as uuidv4 } from 'uuid';
+import { TagInputProps } from './TagInput.types';
+import Tag from './Tag/Tag';
+
+const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
+  (
+    {
+      addOnBlur,
+      onAdd,
+      onBlur: customOnblur,
+      onInputChange,
+      onRemove,
+      values,
+      ...props
+    }: TagInputProps,
+    ref
+  ) => {
+    const id = useMemo(() => uuidv4(), []);
+    const {
+      label,
+      description,
+      required = false,
+      rightSlot,
+      errorText,
+      disabled,
+      onFocus,
+    } = props;
+
+    const [hover, setHover] = useState(false);
+    const [focused, setFocused] = useState(false);
+
+    const [inputValue, setInputValue] = useState<string>('');
+
+    const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (!inputValue && e.key === 'Backspace') {
+        const temp = values.filter((tag) => tag.status !== 'disabled');
+        onRemove(temp[temp.length - 1].value);
+      }
+
+      if (e.key !== 'Enter') {
+        return;
+      }
+
+      if (!inputValue) {
+        console.log('값을 입력해 주세요');
+        return;
+      }
+
+      if (e.nativeEvent.isComposing) {
+        return;
+      }
+
+      onAdd(inputValue);
+      setInputValue('');
+    };
+
+    const onBlur = (e: FocusEvent<HTMLInputElement>) => {
+      if (addOnBlur && inputValue) {
+        onAdd(inputValue);
+        setInputValue('');
+      }
+      setFocused(false);
+      customOnblur?.(e);
+    };
+
+    return (
+      <Styled.Container>
+        {label && (
+          <Styled.LabelWrapper>
+            {required && <Styled.Required>*</Styled.Required>}
+            <Styled.Label
+              htmlFor={id}
+              title={required ? 'This field is required' : ''}
+            >
+              {label}
+            </Styled.Label>
+          </Styled.LabelWrapper>
+        )}
+        {description && <Styled.Description>{description}</Styled.Description>}
+        <Styled.InputWrapper
+          hover={hover}
+          focused={focused}
+          disabled={disabled}
+          error={!!errorText}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+        >
+          <Box
+            style={{ flex: 1 }}
+            paddingTop={8}
+            paddingBottom={8}
+            paddingLeft={12}
+            paddingRight={12}
+            gap={8}
+            $wrap
+          >
+            {!!values.length && (
+              <>
+                {values.map((tag) => (
+                  <Tag
+                    key={tag.value.toString()}
+                    tag={disabled ? { ...tag, status: 'disabled' } : tag}
+                    onRemove={() => {
+                      if (tag.status === 'disabled') {
+                        return;
+                      }
+                      onRemove(tag.value);
+                    }}
+                  />
+                ))}
+              </>
+            )}
+            <Styled.Input
+              ref={ref}
+              id={id}
+              {...props}
+              onFocus={(e) => {
+                onFocus?.(e);
+                setFocused(true);
+              }}
+              onBlur={onBlur}
+              onKeyDown={onKeyDown}
+              value={inputValue}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setInputValue(e.target.value);
+                onInputChange?.();
+              }}
+            />
+          </Box>
+          {rightSlot && (
+            <Styled.RightIconContainer disabled={!!props.disabled}>
+              {rightSlot}
+            </Styled.RightIconContainer>
+          )}
+        </Styled.InputWrapper>
+        {errorText && <Styled.ErrorText>{errorText}</Styled.ErrorText>}
+      </Styled.Container>
+    );
+  }
+);
+
+export default TagInput;

--- a/src/TagInput/TagInput.tsx
+++ b/src/TagInput/TagInput.tsx
@@ -102,7 +102,7 @@ const TagInput = forwardRef<HTMLInputElement, TagInputProps>(
             paddingLeft={12}
             paddingRight={12}
             gap={8}
-            $wrap
+            flexWrap
           >
             {!!values.length && (
               <>

--- a/src/TagInput/TagInput.types.ts
+++ b/src/TagInput/TagInput.types.ts
@@ -1,0 +1,10 @@
+import { TextInputProps } from '../TextInput/TextInput.types';
+import { TagOption } from './Tag/Tag.types';
+
+export type TagInputProps = Omit<TextInputProps, 'leftSlot'> & {
+  values: TagOption[];
+  addOnBlur?: boolean;
+  onAdd: (label: string) => void;
+  onRemove: (value: string) => void;
+  onInputChange?: () => void;
+};

--- a/src/TagInput/index.ts
+++ b/src/TagInput/index.ts
@@ -1,0 +1,1 @@
+export { default as TagInput } from './TagInput';

--- a/src/TagInput/presets/0-default.jsx
+++ b/src/TagInput/presets/0-default.jsx
@@ -1,0 +1,4 @@
+import React from 'react';
+import TagInput from '../TagInput';
+
+export default <TagInput uxpId="TagInput-1" values={[]} />;


### PR DESCRIPTION
# TagInput&Tag

## Props
Tag의 타입을 보시면
value를 string타입으로 가지고 있습니다. (논의가 필요할지도?)
그리고 Tag의 status값을 가지고 있습니다. 그래서 하나의 인풋안에서 여러 상태의 태그가 보여질 수 있습니다.

### Tag
```typescript
export type TagStatus = 'normal' | 'disabled' | 'error';

export type TagOption = Option<string> & {
  status: TagStatus;
};

export type TagProps = {
  tag: TagOption;
  onRemove: (value: string) => void;
};
```
### TagInput
```typescript

export type TagInputProps = Omit<TextInputProps, 'leftSlot'> & {
  values: TagOption[];
  addOnBlur?: boolean;
  onAdd: (label: string) => void;
  onRemove: (value: string) => void;
  onInputChange?: () => void;
};

```


## 구조
- Input Component와 거의 흡사하지만 InputComponent와는 달리 leftSlot에 들어갈 태그의 리스트와 input이 하나의 부모로 묶여있어야하기때문에 새로 컴포넌트를 만들었습니다. 두개가 묶여야하는이유는 flex-wrap이 적용되어야 하기 때문입니다.

## Rule
- 인풋안에있는 태그는 각 상태를 가지지만, 만약 인풋자체가 disabled되어버리면 tag들은 모두 disabled된다.

