### PR TITLE
:sparkles: RadioGroup Component

### DIFF
--- a/src/Radio/Radio.stories.tsx
+++ b/src/Radio/Radio.stories.tsx
@@ -1,0 +1,23 @@
+import Radio from './Radio';
+import { Story, Meta } from '@storybook/react';
+import { RadioProps } from './Radio.types';
+
+export default {
+  title: 'Components/Radio',
+  component: Radio,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<RadioProps> = ({ ...args }) => {
+  return <Radio {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'TEST',
+  value: 'TEST',
+  disabled: false,
+};

--- a/src/Radio/Radio.styled.ts
+++ b/src/Radio/Radio.styled.ts
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components';
+
+export const RadioWrapper = styled.label<{ disabled: boolean }>`
+  ${({ theme, disabled }) => css`
+    display: flex;
+    align-items: center;
+    column-gap: ${theme.spacing.spacing12}px;
+    cursor: ${disabled ? 'default' : 'pointer'};
+  `}
+`;
+
+export const Input = styled.input`
+  ${({ theme }) => css`
+    margin: 0;
+    vertical-align: middle;
+    appearance: none;
+    box-sizing: border-box;
+    border: 1px solid ${theme.colors.N400};
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    &:hover {
+      border: 1px solid ${theme.colors.N600};
+    }
+    &:active {
+      border: 1px solid ${theme.colors.N500};
+      background-color: ${theme.colors.N100};
+    }
+    &:disabled {
+      border: 1px solid ${theme.colors.N100};
+      background-color: ${theme.colors.N100};
+    }
+    &:checked {
+      border: 4px solid ${theme.colors.B400};
+      &:hover {
+        border: 4px solid ${theme.colors.B500};
+      }
+      &:active {
+        border: 4px solid ${theme.colors.B600};
+        background-color: ${theme.colors.transparent};
+      }
+      &:disabled {
+        border: 4px solid ${theme.colors.N100};
+        background-color: ${theme.colors.N500};
+      }
+    }
+  `}
+`;
+
+export const Label = styled.span`
+  ${({ theme }) => css`
+    ${theme.typography.P200};
+    color: ${theme.colors.N800};
+    vertical-align: middle;
+  `}
+`;

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -1,0 +1,31 @@
+import * as Styled from './Radio.styled';
+import { RadioProps } from './Radio.types';
+import { useContext } from 'react';
+import RadioGroupContext from '../RadioGroup/RadioGroupContext';
+
+const Radio = ({ value, label, disabled = false }: RadioProps) => {
+  const {
+    value: selectedValue,
+    name,
+    disabled: groupDisabled,
+    onChange,
+  } = useContext(RadioGroupContext);
+
+  return (
+    <Styled.RadioWrapper disabled={groupDisabled || disabled}>
+      <Styled.Input
+        type="radio"
+        value={value}
+        name={name}
+        checked={selectedValue ? selectedValue === value : undefined}
+        disabled={groupDisabled || disabled}
+        onChange={(e) => {
+          onChange?.(e.target.value);
+        }}
+      />
+      <Styled.Label>{label}</Styled.Label>
+    </Styled.RadioWrapper>
+  );
+};
+
+export default Radio;

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -20,7 +20,7 @@ const Radio = ({ value, label, disabled = false }: RadioProps) => {
         checked={selectedValue ? selectedValue === value : undefined}
         disabled={groupDisabled || disabled}
         onChange={(e) => {
-          onChange?.(e.target.value);
+          onChange?.(e);
         }}
       />
       <Styled.Label>{label}</Styled.Label>

--- a/src/Radio/Radio.types.ts
+++ b/src/Radio/Radio.types.ts
@@ -1,0 +1,5 @@
+export type RadioProps = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};

--- a/src/Radio/index.ts
+++ b/src/Radio/index.ts
@@ -1,0 +1,1 @@
+export { default as Radio } from './Radio';

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,47 @@
+import RadioGroup from './RadioGroup';
+import { Story, Meta } from '@storybook/react';
+import Radio from '../Radio/Radio';
+import { RadioGroupProps } from './RadioGroup.types';
+import { useState } from 'react';
+import { Box } from '../Layout';
+
+export default {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<RadioGroupProps> = ({ ...args }) => {
+  const onChange = (value: string) => {
+    setSelectedValue(value);
+  };
+
+  const [selectedValue, setSelectedValue] = useState<string>('TEST');
+
+  return (
+    <RadioGroup {...args} onChange={onChange} value={selectedValue}>
+      <Box gap={10} direction="column">
+        <Radio value="TEST" label="TEST" />
+        <Radio value="TEST1" label="TEST1" />
+        <Radio value="TEST2" label="TEST2" />
+        <Radio value="TEST3" label="TEST3" />
+      </Box>
+    </RadioGroup>
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  name: 'my',
+};
+
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  name: 'my',
+  disabled: true,
+};

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -2,7 +2,7 @@ import RadioGroup from './RadioGroup';
 import { Story, Meta } from '@storybook/react';
 import Radio from '../Radio/Radio';
 import { RadioGroupProps } from './RadioGroup.types';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { Box } from '../Layout';
 
 export default {
@@ -15,8 +15,8 @@ export default {
 } as Meta;
 
 const Template: Story<RadioGroupProps> = ({ ...args }) => {
-  const onChange = (value: string) => {
-    setSelectedValue(value);
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(e.target.value);
   };
 
   const [selectedValue, setSelectedValue] = useState<string>('TEST');

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,18 @@
+import { RadioGroupProps } from './RadioGroup.types';
+import RadioGroupContext from './RadioGroupContext';
+
+const RadioGroup = ({
+  value,
+  name,
+  disabled = false,
+  children,
+  onChange,
+}: RadioGroupProps) => {
+  return (
+    <RadioGroupContext.Provider value={{ value, name, disabled, onChange }}>
+      {children}
+    </RadioGroupContext.Provider>
+  );
+};
+
+export default RadioGroup;

--- a/src/RadioGroup/RadioGroup.types.ts
+++ b/src/RadioGroup/RadioGroup.types.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 
 export type RadioGroupProps = {
   value: string;
   name: string;
   disabled?: boolean;
-  onChange?: (value: string) => void;
-  children: React.ReactElement;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  children: React.ReactNode;
 };

--- a/src/RadioGroup/RadioGroup.types.ts
+++ b/src/RadioGroup/RadioGroup.types.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export type RadioGroupProps = {
+  value: string;
+  name: string;
+  disabled?: boolean;
+  onChange?: (value: string) => void;
+  children: React.ReactElement;
+};

--- a/src/RadioGroup/RadioGroupContext.tsx
+++ b/src/RadioGroup/RadioGroupContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import { RadioGroupProps } from './RadioGroup.types';
+
+type RadioGroupContextType = Partial<Omit<RadioGroupProps, 'children'>>;
+
+const RadioGroupContext = createContext<RadioGroupContextType>({});
+
+export default RadioGroupContext;

--- a/src/RadioGroup/index.ts
+++ b/src/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { default as RadioGroup } from './RadioGroup';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './Layout';
 export * from './TextInput';
 export * from './Textarea';
 export * from './Checkbox';
+export * from './RadioGroup';


### PR DESCRIPTION
# RadioGroup Component
## Props
### Radio
```typescript
export type RadioProps = {
  value: string;
  label: string;
  disabled?: boolean;
};
```
### RadioGroup
```typescript
export type RadioGroupProps = {
  value: string;
  name: string;
  disabled?: boolean;
  onChange?: (value: string) => void;
  children: React.ReactElement;
};
```

## 설계
- [HTML&CSS](https://www.daleseo.com/css-html-radio/)와 [Context](https://www.daleseo.com/react-radio-buttons/)구조를 참고 했습니다.
- RadioGroup에서 실제 선택된 값을 받고, 그 값들을 context로 관리해 각 group 컴포넌트 내에서 값을 읽어서 checked상태를 구분하도록 했습니다.
- RadioGroup은 데이터 관리의 역할만 하므로, Radio의 구조를 변경하는것은 사용하는 측에서 자유롭게 처리하시면 됩니다.