### PR TITLE
:sparkles: Toggle Component

### DIFF
--- a/src/Toggle/Toggle.stories.tsx
+++ b/src/Toggle/Toggle.stories.tsx
@@ -1,0 +1,37 @@
+import Toggle from './Toggle';
+import { useState } from 'react';
+import { Story, Meta } from '@storybook/react';
+import { ToggleProps } from './Toggle.types';
+
+export default {
+  title: 'Components/Toggle',
+  component: Toggle,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<ToggleProps> = ({ on: defaultOn, ...args }) => {
+  const [on, setOn] = useState(defaultOn);
+  return <Toggle {...args} on={on} onChange={setOn} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Enabled = Template.bind({});
+Enabled.args = {
+  on: true,
+};
+
+export const DefaultWithLabel = Template.bind({});
+DefaultWithLabel.args = {
+  label: 'Toggle Button',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  label: 'Toggle Button',
+  disabled: true,
+};

--- a/src/Toggle/Toggle.styled.ts
+++ b/src/Toggle/Toggle.styled.ts
@@ -28,7 +28,6 @@ export const Input = styled.input`
       width: 12px;
       height: 12px;
       border-radius: 50%;
-      transform: scale(0.8);
       background-color: ${theme.colors.N0};
       transition: left 150ms linear;
     }

--- a/src/Toggle/Toggle.styled.ts
+++ b/src/Toggle/Toggle.styled.ts
@@ -1,0 +1,70 @@
+import styled, { css } from 'styled-components';
+
+export const Container = styled.label<{ disabled: boolean }>`
+  ${({ theme, disabled }) => css`
+    display: inline-flex;
+    align-items: center;
+    gap: ${theme.spacing.spacing12}px;
+    cursor: ${disabled ? 'default' : 'pointer'};
+  `}
+`;
+
+export const Input = styled.input`
+  ${({ theme }) => css`
+    appearance: none;
+    margin: 0;
+    position: relative;
+    border-radius: 8px;
+    box-sizing: border-box;
+    width: 28px;
+    height: 16px;
+    background-color: ${theme.colors.N400};
+    cursor: pointer;
+    &::before {
+      content: '';
+      position: absolute;
+      left: 2px;
+      top: 2px;
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      transform: scale(0.8);
+      background-color: ${theme.colors.N0};
+      transition: left 250ms linear;
+    }
+    &:hover {
+      background-color: ${theme.colors.N500};
+    }
+    &:active {
+      background-color: ${theme.colors.N600};
+    }
+
+    &:checked {
+      background-color: ${theme.colors.B400};
+      &::before {
+        left: 14px;
+      }
+      &:hover {
+        background-color: ${theme.colors.B500};
+      }
+      &:active {
+        background-color: ${theme.colors.B600};
+      }
+    }
+    &:disabled,
+    &:checked:disabled {
+      cursor: default;
+      background-color: ${theme.colors.N100};
+      &::before {
+        background-color: ${theme.colors.N400};
+      }
+    }
+  `}
+`;
+
+export const Label = styled.span`
+  ${({ theme }) => css`
+    ${theme.typography.P200};
+    color: ${theme.colors.N800};
+  `}
+`;

--- a/src/Toggle/Toggle.styled.ts
+++ b/src/Toggle/Toggle.styled.ts
@@ -30,7 +30,7 @@ export const Input = styled.input`
       border-radius: 50%;
       transform: scale(0.8);
       background-color: ${theme.colors.N0};
-      transition: left 250ms linear;
+      transition: left 150ms linear;
     }
     &:hover {
       background-color: ${theme.colors.N500};

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import * as Styled from './Toggle.styled';
+import { ToggleProps } from './Toggle.types';
+import { v4 as uuidv4 } from 'uuid';
+
+const Toggle = (props: ToggleProps) => {
+  const id = useMemo(() => uuidv4(), []);
+  const { label, disabled = false, on, onChange } = props;
+
+  return (
+    <Styled.Container disabled={disabled}>
+      <Styled.Input
+        id={id}
+        role="switch"
+        type="checkbox"
+        disabled={disabled}
+        checked={on}
+        onChange={() => onChange(!on)}
+      />
+      {label && <Styled.Label>{label}</Styled.Label>}
+    </Styled.Container>
+  );
+};
+
+export default Toggle;

--- a/src/Toggle/Toggle.tsx
+++ b/src/Toggle/Toggle.tsx
@@ -1,16 +1,13 @@
 import { useMemo } from 'react';
 import * as Styled from './Toggle.styled';
 import { ToggleProps } from './Toggle.types';
-import { v4 as uuidv4 } from 'uuid';
 
 const Toggle = (props: ToggleProps) => {
-  const id = useMemo(() => uuidv4(), []);
   const { label, disabled = false, on, onChange } = props;
 
   return (
     <Styled.Container disabled={disabled}>
       <Styled.Input
-        id={id}
         role="switch"
         type="checkbox"
         disabled={disabled}

--- a/src/Toggle/Toggle.types.ts
+++ b/src/Toggle/Toggle.types.ts
@@ -1,0 +1,6 @@
+export type ToggleProps = {
+  label?: string;
+  disabled?: boolean;
+  on: boolean;
+  onChange: (on: boolean) => void;
+};

--- a/src/Toggle/index.ts
+++ b/src/Toggle/index.ts
@@ -1,0 +1,1 @@
+export { default as Toggle } from './Toggle';


### PR DESCRIPTION
# Toggle Component
## Props
```typescript
export type ToggleProps = {
  label?: string;
  disabled?: boolean;
  on: boolean;
  onChange: (on: boolean) => void;
};
```

## 설계
- 웹 접근성을 위해서 input > checkbox로 토글 버튼을 만들었습니다. input의 스타일이 보이지않게 처리하고 css로 토글을 만들었습니다.