### PR TITLE
:sparkles: Checkbox Component

### DIFF
--- a/src/Checkbox/Checkbox.stories.tsx
+++ b/src/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,46 @@
+import Checkbox from './Checkbox';
+import { Story, Meta } from '@storybook/react';
+import { CheckboxProps } from './Checkbox.types';
+import { Box } from '../Layout';
+import { useState } from 'react';
+
+export default {
+  title: 'Components/Checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<CheckboxProps> = ({ ...args }) => {
+  const [checked, setChecked] = useState(false);
+
+  const onChange = () => {
+    setChecked(!checked);
+  };
+
+  return (
+    <Box gap={12} direction="column">
+      <Checkbox {...args} onChange={onChange} checked={checked} />
+      <Checkbox {...args} disabled onChange={onChange} checked={checked} />
+    </Box>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'TEST',
+};
+
+export const Indeterminate = Template.bind({});
+Indeterminate.args = {
+  label: 'TEST',
+  indeterminate: true,
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+  label: 'TEST',
+  checked: true,
+};

--- a/src/Checkbox/Checkbox.styled.ts
+++ b/src/Checkbox/Checkbox.styled.ts
@@ -9,6 +9,9 @@ export const Container = styled.label<{ disabled: boolean }>`
     align-items: center;
     column-gap: ${theme.spacing.spacing12}px;
     cursor: ${disabled ? 'default' : 'pointer'};
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
   `}
 `;
 

--- a/src/Checkbox/Checkbox.styled.ts
+++ b/src/Checkbox/Checkbox.styled.ts
@@ -1,0 +1,91 @@
+import styled, { css } from 'styled-components';
+import { Box } from '../Layout';
+
+export const Container = styled.label<{ disabled: boolean }>`
+  ${({ theme, disabled }) => css`
+    box-sizing: border-box;
+    display: flex;
+    flex: 1;
+    align-items: center;
+    column-gap: ${theme.spacing.spacing12}px;
+    cursor: ${disabled ? 'default' : 'pointer'};
+  `}
+`;
+
+export const Checkbox = styled(Box)<{
+  disabled: boolean;
+  hover: boolean;
+  checked: boolean;
+  pressed: boolean;
+}>`
+  ${({ theme, hover, checked, disabled, pressed }) => css`
+    width: 16px;
+    height: 16px;
+    border-radius: 4px;
+    position: relative;
+    box-sizing: border-box;
+    border: 1px solid ${theme.colors.N400};
+    & svg {
+      color: ${theme.colors.N0};
+    }
+    ${hover &&
+    css`
+      border: 1px solid ${theme.colors.N600};
+    `}
+    ${pressed &&
+    css`
+      border: 1px solid ${theme.colors.N500};
+      background-color: ${theme.colors.N100};
+    `}
+    ${disabled &&
+    css`
+      border: 1px solid ${theme.colors.N100};
+      background-color: ${theme.colors.N100};
+      & svg {
+        color: ${theme.colors.N500};
+      }
+    `}
+    ${checked &&
+    css`
+      background-color: ${theme.colors.B400};
+      border: none;
+      ${hover &&
+      css`
+        background-color: ${theme.colors.B500};
+      `}
+      ${pressed &&
+      css`
+        background-color: ${theme.colors.B600};
+      `}
+    ${disabled &&
+      css`
+        background-color: ${theme.colors.N100};
+      `}
+    `}
+  `}
+`;
+
+export const Input = styled.input`
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+`;
+
+export const Label = styled.span`
+  ${({ theme }) =>
+    css`
+      ${theme.typography.P200}
+      color:${theme.colors.N800};
+    `}
+`;
+
+export const Indeterminate = styled.div`
+  ${({ theme }) =>
+    css`
+      width: 8px;
+      height: 2px;
+      border-radius: 1px;
+      background-color: ${theme.colors.N0};
+    `}
+`;

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,0 +1,63 @@
+import { useMemo, useState } from 'react';
+import * as Styled from './Checkbox.styled';
+import { CheckboxProps } from './Checkbox.types';
+import { v4 as uuidv4 } from 'uuid';
+import { Box } from '../Layout';
+import ActionSmallTickIcon from '../parte-icons/Icons/ActionSmallTickIcon';
+
+const Checkbox = ({
+  label,
+  disabled = false,
+  checked = false,
+  indeterminate = false,
+  onChange,
+}: CheckboxProps) => {
+  const id = useMemo(() => uuidv4(), []);
+
+  const [hover, setHover] = useState(false);
+  const [pressed, setPressed] = useState(false);
+
+  const renderIcon = () => {
+    if (checked) {
+      return <ActionSmallTickIcon size={16} />;
+    }
+    if (indeterminate) {
+      return <Styled.Indeterminate />;
+    }
+    return <></>;
+  };
+
+  return (
+    <Styled.Container
+      disabled={disabled}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onMouseDown={() => setPressed(true)}
+      onMouseUp={() => setPressed(false)}
+    >
+      <Styled.Checkbox
+        hover={hover}
+        pressed={pressed}
+        checked={checked || indeterminate}
+        disabled={disabled}
+        alignItems="Center"
+      >
+        <Styled.Input
+          id={id}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          onChange={(e) => {
+            onChange(e);
+          }}
+        />
+        <Box alignItems="Center" justifyContent="Center" style={{ flex: 1 }}>
+          {renderIcon()}
+        </Box>
+      </Styled.Checkbox>
+      <Styled.Label>{label}</Styled.Label>
+    </Styled.Container>
+  );
+};
+
+export default Checkbox;

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import * as Styled from './Checkbox.styled';
 import { CheckboxProps } from './Checkbox.types';
-import { v4 as uuidv4 } from 'uuid';
 import { Box } from '../Layout';
 import ActionSmallTickIcon from '../parte-icons/Icons/ActionSmallTickIcon';
 
@@ -12,17 +11,15 @@ const Checkbox = ({
   indeterminate = false,
   onChange,
 }: CheckboxProps) => {
-  const id = useMemo(() => uuidv4(), []);
-
   const [hover, setHover] = useState(false);
   const [pressed, setPressed] = useState(false);
 
   const renderIcon = () => {
-    if (checked) {
-      return <ActionSmallTickIcon size={16} />;
-    }
     if (indeterminate) {
       return <Styled.Indeterminate />;
+    }
+    if (checked) {
+      return <ActionSmallTickIcon size={16} />;
     }
     return <></>;
   };
@@ -43,7 +40,6 @@ const Checkbox = ({
         alignItems="Center"
       >
         <Styled.Input
-          id={id}
           type="checkbox"
           checked={checked}
           disabled={disabled}

--- a/src/Checkbox/Checkbox.types.ts
+++ b/src/Checkbox/Checkbox.types.ts
@@ -1,0 +1,9 @@
+import { ChangeEvent } from 'react';
+
+export type CheckboxProps = {
+  label: string;
+  disabled?: boolean;
+  indeterminate?: boolean;
+  checked?: boolean;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+};

--- a/src/Checkbox/index.ts
+++ b/src/Checkbox/index.ts
@@ -1,0 +1,1 @@
+export { default as Checkbox } from './Checkbox';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ export * from './IconButton';
 export * from './Layout';
 export * from './TextInput';
 export * from './Textarea';
+export * from './Checkbox';


### PR DESCRIPTION
# Checkbox Component
## Props
```typescript
export type CheckboxProps = {
  label: string;
  disabled?: boolean;
  indeterminate?: boolean;
  checked?: boolean;
  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
};
```

## 설계
- Input의 속성을 사용하면서, 커스텀한 디자인의 체크박스를 만들기위해, 컴포넌트 전체를 label tag로 감싸고 내부에 input을 배치했습니다.
이렇게 하면 label과 input이 연결되기때문에 텍스트를 눌러도 input의 onChange가 실행됩니다.
- Input을 숨기고, 그 위에 커스텀한 컴포넌트를 그리도록 했습니다.

## 디자인
- default, indeterminate, checked의 상태에따른 디자인을 확인해주시면 됩니다.