### PR TITLE
:lipstick: add pretendard

### DIFF
--- a/src/@foundations/Colors/ColorList.tsx
+++ b/src/@foundations/Colors/ColorList.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import React from 'react';
 import colors from './colors';
 
 const CATEGORY = [
@@ -58,7 +57,6 @@ const Container = styled.div`
 `;
 
 const Title = styled.h2`
-  font-family: sans-serif;
   color: #4f4f4f;
 `;
 
@@ -74,7 +72,6 @@ const Item = styled.div<{ color: string }>`
   height: 100%;
   border-radius: 8px;
   padding: 8px;
-  font-family: sans-serif;
   box-sizing: border-box;
   box-shadow: 0 0 2px 0px rgba(0, 0, 0, 0.2);
   background-color: ${({ color }) => color};

--- a/src/@foundations/Typography/typography.ts
+++ b/src/@foundations/Typography/typography.ts
@@ -2,11 +2,9 @@ import { css } from 'styled-components';
 import { COLORS } from '../Colors';
 
 const commonBaseTextStyle = css`
-  font-family: 'SF Pro Text';
   font-style: normal;
 `;
 const commonCodeStyle = css`
-  font-family: 'SF Mono';
   font-style: italic;
   font-weight: 400;
   font-size: 14px;

--- a/src/Button/Button.styled.ts
+++ b/src/Button/Button.styled.ts
@@ -23,7 +23,7 @@ const commonButtonStyles = css<ButtonProps>`
     `${theme.spacing.spacing8}px ${theme.spacing.spacing16}px`};
   column-gap: 8px;
   border-radius: 4px;
-
+  font-family: inherit;
   &::-moz-focus-inner {
     border: 0;
   }

--- a/src/TextInput/TextInput.styled.ts
+++ b/src/TextInput/TextInput.styled.ts
@@ -141,7 +141,7 @@ export const Input = styled.input<TextInputProps>`
     width: ${fullWidth ? '100%' : 'fit-content'};
     color: ${theme.colorParagraph};
     ${theme.typography.P100}
-
+    font-family: inherit;
     ::placeholder {
       color: ${theme.colorTextPlaceholderDefault};
     }

--- a/src/Textarea/Textarea.styled.ts
+++ b/src/Textarea/Textarea.styled.ts
@@ -113,6 +113,7 @@ export const Textarea = styled.textarea<{
     color: ${theme.colorParagraph};
     ${theme.typography.P100}
     display: inline-flex;
+    font-family: inherit;
     ::placeholder {
       color: ${theme.colorTextPlaceholderDefault};
     }

--- a/src/common/styleReset.ts
+++ b/src/common/styleReset.ts
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 
 export default css`
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css');
   html,
   body,
   div,
@@ -86,7 +87,6 @@ export default css`
     padding: 0;
     border: 0;
     font-size: 100%;
-    font: inherit;
     vertical-align: baseline;
   }
   /* HTML5 display-role reset for older browsers */
@@ -102,9 +102,6 @@ export default css`
   nav,
   section {
     display: block;
-  }
-  body {
-    line-height: 1.5;
   }
   ol,
   ul {
@@ -137,12 +134,21 @@ export default css`
     outline: none;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   }
+
   body {
     margin: 0;
     padding: 0;
-    font-family: sans-serif;
-    color: black;
   }
+
+  input,
+  textarea,
+  body {
+    font-family: 'Pretendard Variable', Pretendard, -apple-system,
+      BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
+      'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
+      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+  }
+
   code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
       monospace;


### PR DESCRIPTION
# Pretendard font 추가
## 내용
```css
@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css');
```
```css
font-family: 'Pretendard Variable', Pretendard, -apple-system,
      BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
      'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
```
## 설계
- styleReset 첫단에 cdn링크로 폰트 받아옴
- OS와 상관없이 pretendard가 1순위로 적용되어 동일한 폰트 제공
## 디자인
- 각 컴포넌트 별로 위 폰트가 제대로 적용이 되었는지 확인 부탁드려요
- changeset 보시면 input / textarea 가 길어지는것처럼 나오는데, snapshot에서만 달라진것이고, 스토리북가서 실제 컴포넌트 보시면 width에 변화는 없습니다. 왜 이러는지는 저도 잘 모르겠네요...