### PR TITLE
:sparkles: add steps component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parte-ui",
   "private": false,
-  "version": "0.0.0",
+  "version": "0.1.22",
   "main": "./dist/index.umd.js",
   "module": "./dist/index.es.js",
   "typings": "./dist/index.d.ts",

--- a/src/Radio/Radio.stories.tsx
+++ b/src/Radio/Radio.stories.tsx
@@ -1,0 +1,23 @@
+import Radio from './Radio';
+import { Story, Meta } from '@storybook/react';
+import { RadioProps } from './Radio.types';
+
+export default {
+  title: 'Components/Radio',
+  component: Radio,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<RadioProps> = ({ ...args }) => {
+  return <Radio {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'TEST',
+  value: 'TEST',
+  disabled: false,
+};

--- a/src/Radio/Radio.styled.ts
+++ b/src/Radio/Radio.styled.ts
@@ -1,0 +1,56 @@
+import styled, { css } from 'styled-components';
+
+export const RadioWrapper = styled.label<{ disabled: boolean }>`
+  ${({ theme, disabled }) => css`
+    display: flex;
+    align-items: center;
+    column-gap: ${theme.spacing.spacing12}px;
+    cursor: ${disabled ? 'default' : 'pointer'};
+  `}
+`;
+
+export const Input = styled.input`
+  ${({ theme }) => css`
+    margin: 0;
+    vertical-align: middle;
+    appearance: none;
+    box-sizing: border-box;
+    border: 1px solid ${theme.colors.N400};
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    &:hover {
+      border: 1px solid ${theme.colors.N600};
+    }
+    &:active {
+      border: 1px solid ${theme.colors.N500};
+      background-color: ${theme.colors.N100};
+    }
+    &:disabled {
+      border: 1px solid ${theme.colors.N100};
+      background-color: ${theme.colors.N100};
+    }
+    &:checked {
+      border: 4px solid ${theme.colors.B400};
+      &:hover {
+        border: 4px solid ${theme.colors.B500};
+      }
+      &:active {
+        border: 4px solid ${theme.colors.B600};
+        background-color: ${theme.colors.transparent};
+      }
+      &:disabled {
+        border: 4px solid ${theme.colors.N100};
+        background-color: ${theme.colors.N500};
+      }
+    }
+  `}
+`;
+
+export const Label = styled.span`
+  ${({ theme }) => css`
+    ${theme.typography.P200};
+    color: ${theme.colors.N800};
+    vertical-align: middle;
+  `}
+`;

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -1,0 +1,31 @@
+import * as Styled from './Radio.styled';
+import { RadioProps } from './Radio.types';
+import { useContext } from 'react';
+import RadioGroupContext from '../RadioGroup/RadioGroupContext';
+
+const Radio = ({ value, label, disabled = false }: RadioProps) => {
+  const {
+    value: selectedValue,
+    name,
+    disabled: groupDisabled,
+    onChange,
+  } = useContext(RadioGroupContext);
+
+  return (
+    <Styled.RadioWrapper disabled={groupDisabled || disabled}>
+      <Styled.Input
+        type="radio"
+        value={value}
+        name={name}
+        checked={selectedValue ? selectedValue === value : undefined}
+        disabled={groupDisabled || disabled}
+        onChange={(e) => {
+          onChange?.(e.target.value);
+        }}
+      />
+      <Styled.Label>{label}</Styled.Label>
+    </Styled.RadioWrapper>
+  );
+};
+
+export default Radio;

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -20,7 +20,7 @@ const Radio = ({ value, label, disabled = false }: RadioProps) => {
         checked={selectedValue ? selectedValue === value : undefined}
         disabled={groupDisabled || disabled}
         onChange={(e) => {
-          onChange?.(e.target.value);
+          onChange?.(e);
         }}
       />
       <Styled.Label>{label}</Styled.Label>

--- a/src/Radio/Radio.types.ts
+++ b/src/Radio/Radio.types.ts
@@ -1,0 +1,5 @@
+export type RadioProps = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};

--- a/src/Radio/index.ts
+++ b/src/Radio/index.ts
@@ -1,0 +1,1 @@
+export { default as Radio } from './Radio';

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -1,0 +1,47 @@
+import RadioGroup from './RadioGroup';
+import { Story, Meta } from '@storybook/react';
+import Radio from '../Radio/Radio';
+import { RadioGroupProps } from './RadioGroup.types';
+import { useState } from 'react';
+import { Box } from '../Layout';
+
+export default {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<RadioGroupProps> = ({ ...args }) => {
+  const onChange = (value: string) => {
+    setSelectedValue(value);
+  };
+
+  const [selectedValue, setSelectedValue] = useState<string>('TEST');
+
+  return (
+    <RadioGroup {...args} onChange={onChange} value={selectedValue}>
+      <Box gap={10} direction="column">
+        <Radio value="TEST" label="TEST" />
+        <Radio value="TEST1" label="TEST1" />
+        <Radio value="TEST2" label="TEST2" />
+        <Radio value="TEST3" label="TEST3" />
+      </Box>
+    </RadioGroup>
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  name: 'my',
+};
+
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  name: 'my',
+  disabled: true,
+};

--- a/src/RadioGroup/RadioGroup.stories.tsx
+++ b/src/RadioGroup/RadioGroup.stories.tsx
@@ -2,7 +2,7 @@ import RadioGroup from './RadioGroup';
 import { Story, Meta } from '@storybook/react';
 import Radio from '../Radio/Radio';
 import { RadioGroupProps } from './RadioGroup.types';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { Box } from '../Layout';
 
 export default {
@@ -15,8 +15,8 @@ export default {
 } as Meta;
 
 const Template: Story<RadioGroupProps> = ({ ...args }) => {
-  const onChange = (value: string) => {
-    setSelectedValue(value);
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(e.target.value);
   };
 
   const [selectedValue, setSelectedValue] = useState<string>('TEST');

--- a/src/RadioGroup/RadioGroup.tsx
+++ b/src/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,18 @@
+import { RadioGroupProps } from './RadioGroup.types';
+import RadioGroupContext from './RadioGroupContext';
+
+const RadioGroup = ({
+  value,
+  name,
+  disabled = false,
+  children,
+  onChange,
+}: RadioGroupProps) => {
+  return (
+    <RadioGroupContext.Provider value={{ value, name, disabled, onChange }}>
+      {children}
+    </RadioGroupContext.Provider>
+  );
+};
+
+export default RadioGroup;

--- a/src/RadioGroup/RadioGroup.types.ts
+++ b/src/RadioGroup/RadioGroup.types.ts
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 
 export type RadioGroupProps = {
   value: string;
   name: string;
   disabled?: boolean;
-  onChange?: (value: string) => void;
-  children: React.ReactElement;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  children: React.ReactNode;
 };

--- a/src/RadioGroup/RadioGroup.types.ts
+++ b/src/RadioGroup/RadioGroup.types.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export type RadioGroupProps = {
+  value: string;
+  name: string;
+  disabled?: boolean;
+  onChange?: (value: string) => void;
+  children: React.ReactElement;
+};

--- a/src/RadioGroup/RadioGroupContext.tsx
+++ b/src/RadioGroup/RadioGroupContext.tsx
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import { RadioGroupProps } from './RadioGroup.types';
+
+type RadioGroupContextType = Partial<Omit<RadioGroupProps, 'children'>>;
+
+const RadioGroupContext = createContext<RadioGroupContextType>({});
+
+export default RadioGroupContext;

--- a/src/RadioGroup/index.ts
+++ b/src/RadioGroup/index.ts
@@ -1,0 +1,1 @@
+export { default as RadioGroup } from './RadioGroup';

--- a/src/Steps/Step/Step.stories.tsx
+++ b/src/Steps/Step/Step.stories.tsx
@@ -1,0 +1,29 @@
+import Step from './Step';
+import { Story, Meta } from '@storybook/react';
+import { StepProps } from './Step.types';
+
+export default {
+  title: 'Components/Steps/Step',
+  component: Step,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<StepProps> = ({ ...args }) => {
+  return <Step {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  label: 'Not Started',
+  currentStep: 0,
+  stepIndex: 1,
+};
+
+export const InProgress = Template.bind({});
+InProgress.args = { label: 'In Progress', currentStep: 1, stepIndex: 1 };
+
+export const Complete = Template.bind({});
+Complete.args = { label: 'Complete', currentStep: 2, stepIndex: 1 };

--- a/src/Steps/Step/Step.stories.tsx
+++ b/src/Steps/Step/Step.stories.tsx
@@ -23,7 +23,7 @@ Default.args = {
 };
 
 export const InProgress = Template.bind({});
-InProgress.args = { label: 'In Progress', currentStep: 1, stepIndex: 1 };
+InProgress.args = { label: 'In progress', currentStep: 1, stepIndex: 1 };
 
 export const Complete = Template.bind({});
 Complete.args = { label: 'Complete', currentStep: 2, stepIndex: 1 };

--- a/src/Steps/Step/Step.styled.ts
+++ b/src/Steps/Step/Step.styled.ts
@@ -33,14 +33,17 @@ export const Icon = styled(Box)<{ status: StepStatus }>`
     `}
       ${status === 'complete' &&
     css`
-      color: ${theme.colors.G400};
       background-color: ${theme.colors.G200};
     `}
   `}
 `;
 export const Label = styled.span<{ status: StepStatus }>`
-  ${({ theme }) => css`
-    ${theme.typography.H300}
-    color: ${theme.colors.N700}
+  ${({ theme, status }) => css`
+    color: ${theme.colors.N700};
+    ${theme.typography.H300};
+    ${status === 'inProgress' &&
+    css`
+      color: ${theme.colors.B400};
+    `}
   `}
 `;

--- a/src/Steps/Step/Step.styled.ts
+++ b/src/Steps/Step/Step.styled.ts
@@ -1,0 +1,46 @@
+import styled, { css } from 'styled-components';
+import { Box } from '../../Layout';
+import { StepProps, StepStatus } from './Step.types';
+
+export const Container = styled(Box)`
+  ${({ theme }) => css`
+    width: fit-content;
+    align-items: center;
+    user-select: none;
+  `}
+`;
+export const Icon = styled(Box)<{ status: StepStatus }>`
+  ${({ theme, status }) => css`
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    align-items: center;
+    border-radius: 4px;
+    // 타이포그래피에 없는 글자 포맷이네요
+    font-weight: 600;
+    font-size: 10px;
+    line-height: 8px;
+
+    ${status === 'notStarted' &&
+    css`
+      color: ${theme.colors.N700};
+      background-color: ${theme.colors.N200};
+    `}
+    ${status === 'inProgress' &&
+    css`
+      color: ${theme.colors.B500};
+      background-color: ${theme.colors.B200};
+    `}
+      ${status === 'complete' &&
+    css`
+      color: ${theme.colors.G400};
+      background-color: ${theme.colors.G200};
+    `}
+  `}
+`;
+export const Label = styled.span<{ status: StepStatus }>`
+  ${({ theme }) => css`
+    ${theme.typography.H300}
+    color: ${theme.colors.N700}
+  `}
+`;

--- a/src/Steps/Step/Step.tsx
+++ b/src/Steps/Step/Step.tsx
@@ -1,0 +1,31 @@
+import ActionTickIcon from '../../parte-icons/Icons/ActionTickIcon';
+import * as Styled from './Step.styled';
+import { StepProps, StepStatus } from './Step.types';
+
+function Step({ label, currentStep, stepIndex }: StepProps) {
+  const stepValidator = (): StepStatus => {
+    if (stepIndex === currentStep) {
+      return 'inProgress';
+    } else if (stepIndex < currentStep) {
+      return 'complete';
+    }
+    return 'notStarted';
+  };
+
+  const stepStatus = stepValidator();
+
+  return (
+    <Styled.Container gap={8}>
+      <Styled.Icon status={stepStatus}>
+        {stepStatus === 'complete' ? (
+          <ActionTickIcon size={8} color="success" />
+        ) : (
+          stepIndex
+        )}
+      </Styled.Icon>
+      <Styled.Label status={stepStatus}>{label}</Styled.Label>
+    </Styled.Container>
+  );
+}
+
+export default Step;

--- a/src/Steps/Step/Step.types.ts
+++ b/src/Steps/Step/Step.types.ts
@@ -1,0 +1,12 @@
+// 현재 스텝에 대한 정보
+
+export type StepStatus = 'complete' | 'inProgress' | 'notStarted';
+
+export type StepProps = {
+  /**
+   * @label 값을 주지 않으면 아이콘만 표기됩니다.
+   */
+  label?: string;
+  currentStep: number;
+  stepIndex: number;
+};

--- a/src/Steps/Step/index.ts
+++ b/src/Steps/Step/index.ts
@@ -1,0 +1,1 @@
+export { default as Step } from './Step';

--- a/src/Steps/Steps.stories.tsx
+++ b/src/Steps/Steps.stories.tsx
@@ -1,0 +1,44 @@
+import Steps from './Steps';
+import { Story, Meta } from '@storybook/react';
+import { StepsProps } from './Steps.types';
+
+export default {
+  title: 'Components/Steps',
+  component: Steps,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<StepsProps> = ({ ...args }) => {
+  return <Steps {...args} />;
+};
+
+const MOCK = [
+  {
+    name: '냉장고 확인',
+  },
+  {
+    name: '운전해서 상점으로 가기',
+  },
+  {
+    name: '필요한 것 구입하기',
+  },
+  {
+    name: '운전해서 집으로 오기',
+  },
+  {
+    name: '음식을 냉장고에 보관하기',
+  },
+].map((v, i) => {
+  return {
+    id: i,
+    label: v.name,
+  };
+});
+export const Default = Template.bind({});
+Default.args = {
+  stepList: MOCK,
+  currentStep: MOCK.findIndex((v) => v.id === 3),
+};

--- a/src/Steps/Steps.styled.ts
+++ b/src/Steps/Steps.styled.ts
@@ -1,0 +1,8 @@
+import styled, { css } from 'styled-components';
+import { Box } from '../Layout';
+
+export const Steps = styled(Box)`
+  ${({ theme }) => css`
+    gap: ${theme.spacing.spacing24}px;
+  `}
+`;

--- a/src/Steps/Steps.tsx
+++ b/src/Steps/Steps.tsx
@@ -1,0 +1,15 @@
+import Step from './Step/Step';
+import * as Styled from './Steps.styled';
+import { StepsProps } from './Steps.types';
+
+const Steps = ({ stepList, currentStep }: StepsProps) => {
+  return (
+    <Styled.Steps>
+      {stepList.map((step, index) => (
+        <Step currentStep={currentStep} stepIndex={index} label={step.label} />
+      ))}
+    </Styled.Steps>
+  );
+};
+
+export default Steps;

--- a/src/Steps/Steps.types.ts
+++ b/src/Steps/Steps.types.ts
@@ -1,0 +1,6 @@
+import { HTMLAttributes } from 'react';
+
+export type StepsProps = HTMLAttributes<HTMLDivElement> & {
+  stepList: { id: number; label: string }[];
+  currentStep: number;
+};

--- a/src/Steps/index.ts
+++ b/src/Steps/index.ts
@@ -1,0 +1,1 @@
+export { default as Steps } from './Steps';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './TextInput';
 export * from './Textarea';
 export * from './Checkbox';
 export * from './Steps';
+export * from './RadioGroup';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,4 @@ export * from './Textarea';
 export * from './Checkbox';
 export * from './Steps';
 export * from './RadioGroup';
+export * from './Steps';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './Layout';
 export * from './TextInput';
 export * from './Textarea';
 export * from './Checkbox';
+export * from './Steps';


### PR DESCRIPTION
# Steps Component
## Props
```typescript
export type StepsProps = HTMLAttributes<HTMLDivElement> & {
  stepList: { label: string }[];
  currentStep: number;
};
```

## 설계
- Steps 에 단계별 데이터를 넣어줍니다. 현재는 label말고 딱히 필요한게 없습니다.
- currentStep은 단계별 데이터중 현재 해당하는 index를 넣어줍니다.

```typescript
// stepIndex가 currentStep 같으면 INPROGRESS
// stepIndex가 currentStep 보다 작으면 COMPLETE
// stepIndex가 currentStep 보다 크면 NOTSTARTED
```

## 디자인
- preset으로 3가지 상태를 스토리북에서 볼 수 있습니다.
- 어제 이야기 나눈대로 인터렉션은 전혀 없습니다,

## 기타
음슴