### PR TITLE
:label: button 내장 attribute 타입 변경

### DIFF
--- a/src/Button/Button.types.ts
+++ b/src/Button/Button.types.ts
@@ -1,6 +1,6 @@
-import React, { HTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 
-export type ButtonProps = HTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant: 'primary' | 'secondary' | 'minimal' | 'error';
   leftSlot?: React.ReactNode;
   rightSlot?: React.ReactNode;


### PR DESCRIPTION
버튼 props타입을 변경했습니다.
`props.type`을 찍어보니 type 프로퍼티가 없다는 에러가 나서 버튼의 attribute를 설정하는 방식을 변경했습니다.

