### PR TITLE
:sparkles: filePicker Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",
     "@storybook/addon-links": "^6.5.16",
-    "@storybook/builder-vite": "^0.2.5",
+    "@storybook/builder-vite": "^0.4.2",
     "@storybook/react": "^6.5.16",
     "@storybook/testing-library": "^0.0.13",
     "@tanstack/react-table": "^8.7.9",

--- a/src/Button/Button.styled.ts
+++ b/src/Button/Button.styled.ts
@@ -3,7 +3,6 @@ import { ButtonProps } from './Button.types';
 
 const commonButtonStyles = css<ButtonProps>`
   position: relative;
-  font-weight: 500;
   display: inline-flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -15,6 +14,7 @@ const commonButtonStyles = css<ButtonProps>`
   user-select: none;
   cursor: pointer;
   white-space: nowrap;
+  box-sizing: border-box;
   width: ${({ fullWidth }) => (fullWidth ? '100%' : 'fit-content')};
   -webkit-font-smoothing: antialiased;
   -webkit-appearance: none;
@@ -24,6 +24,9 @@ const commonButtonStyles = css<ButtonProps>`
   column-gap: 8px;
   border-radius: 4px;
   font-family: inherit;
+  &:disabled {
+    cursor: default;
+  }
   &::-moz-focus-inner {
     border: 0;
   }

--- a/src/Button/Button.types.ts
+++ b/src/Button/Button.types.ts
@@ -3,7 +3,7 @@ import React, { ButtonHTMLAttributes } from 'react';
 export type ButtonVariant = 'primary' | 'secondary' | 'minimal' | 'error';
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant: ButtonVariant;
+  variant?: ButtonVariant;
   leadingIcon?: React.ReactNode;
   trailingIcon?: React.ReactNode;
   disabled?: boolean;

--- a/src/Button/index.ts
+++ b/src/Button/index.ts
@@ -1,1 +1,1 @@
-export { default as Button } from './Button';
+export { default } from './Button';

--- a/src/CornerDialog/CornerDialog.stories.tsx
+++ b/src/CornerDialog/CornerDialog.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/react';
 import { useState } from 'react';
-import { Button } from '../Button';
+import Button from '../Button';
 import CornerDialog from './CornerDialog';
 import { CornerDialogProps } from './CornerDialog.types';
 

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { css } from 'styled-components';
-import { Button } from '../Button';
+import Button from '../Button';
 import { IconButton } from '../IconButton';
 import ActionCrossIcon from '../parte-icons/Icons/ActionCrossIcon';
 import * as Styled from './Dialog.styled';

--- a/src/DialogModal/DialogModal.stories.tsx
+++ b/src/DialogModal/DialogModal.stories.tsx
@@ -1,7 +1,7 @@
 import { Story, Meta } from '@storybook/react';
 import { useState } from 'react';
 import { css } from 'styled-components';
-import { Button } from '../Button';
+import Button from '../Button';
 import theme from '../common/theme';
 import { Box } from '../Layout';
 import DialogModal from './DialogModal';

--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react';
 import { useState } from 'react';
-import { Button } from '../Button';
+import Button from '../Button';
 import ActionChatIcon from '../parte-icons/Icons/ActionChatIcon';
 import Dropdown from './Dropdown';
 import { DropdownProps } from './Dropdown.types';

--- a/src/FilePicker/FilePicker.stories.tsx
+++ b/src/FilePicker/FilePicker.stories.tsx
@@ -1,0 +1,61 @@
+import FilePicker from './FilePicker';
+import { Story, Meta } from '@storybook/react';
+import { FilePickerProps } from './FilePicker.types';
+
+export default {
+  title: 'Components/Forms/FilePicker',
+  component: FilePicker,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<FilePickerProps> = ({ ...args }) => {
+  return <FilePicker {...args} />;
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  name: 'default-file-picker',
+};
+
+export const WithLabel = Template.bind({});
+
+WithLabel.args = {
+  name: 'label-file-picker',
+  label: 'Label',
+  description: 'This is Description',
+};
+
+export const MultipleFiles = Template.bind({});
+
+MultipleFiles.args = {
+  name: 'multi-file-picker',
+  multiple: true,
+};
+
+export const CustomInputName = Template.bind({});
+
+CustomInputName.args = {
+  name: 'custom-name-file-picker',
+  multiple: true,
+  inputText: (files) => files.map((file) => file.name).join(', '),
+};
+
+export const Error = Template.bind({});
+
+Error.args = {
+  name: 'error-file-picker',
+  errorMessage: 'error ocurred',
+  // FIXME: 지우기
+  occurError: true,
+};
+
+export const Disabled = Template.bind({});
+
+Disabled.args = {
+  name: 'disable-file-picker',
+  disabled: true,
+};

--- a/src/FilePicker/FilePicker.stories.tsx
+++ b/src/FilePicker/FilePicker.stories.tsx
@@ -41,16 +41,12 @@ export const CustomInputName = Template.bind({});
 CustomInputName.args = {
   name: 'custom-name-file-picker',
   multiple: true,
-  inputText: (files) => files.map((file) => file.name).join(', '),
-};
-
-export const Error = Template.bind({});
-
-Error.args = {
-  name: 'error-file-picker',
-  errorMessage: 'error ocurred',
-  // FIXME: 지우기
-  occurError: true,
+  inputText: (files) => {
+    if (files.length) {
+      return 'custom file name';
+    }
+    return 'select file';
+  },
 };
 
 export const Disabled = Template.bind({});

--- a/src/FilePicker/FilePicker.styled.ts
+++ b/src/FilePicker/FilePicker.styled.ts
@@ -10,12 +10,17 @@ export const Container = styled(Box)`
 `;
 
 export const FilePickerInput = styled(Box)<{ focused: boolean }>`
-  ${({ focused }) => css`
+  ${({ focused, theme }) => css`
     & input {
       max-width: 100%;
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      caret-color: transparent;
+      cursor: default;
+      &::placeholder {
+        color: ${theme.colorTextPlaceholderDefault} !important;
+      }
     }
     & div#parte-text-input-wrapper {
       border-top-right-radius: 0px;
@@ -28,13 +33,20 @@ export const FilePickerInput = styled(Box)<{ focused: boolean }>`
   `}
 `;
 
-export const FilePickerButton = styled(Button)`
-  ${({ theme }) => css`
+export const FilePickerButton = styled(Button)<{ error: boolean }>`
+  ${({ theme, error }) => css`
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     margin-left: -1px;
     z-index: 1;
     ${theme.typography.C200};
+    ${error &&
+    css`
+      border-color: ${theme.colors.R400} !important;
+      color: ${theme.colors.R400} !important;
+      background-color: ${theme.colorBackgroundButtonSecondary} !important;
+      outline: none !important;
+    `}
   `}
 `;
 

--- a/src/FilePicker/FilePicker.styled.ts
+++ b/src/FilePicker/FilePicker.styled.ts
@@ -1,120 +1,42 @@
 import styled, { css } from 'styled-components';
-import Typography from '../@foundations/Typography/typography';
+import Button from '../Button';
 import { Box } from '../Layout';
 
-export const Container = styled(Box)<{
-  error: boolean;
-  disabled: boolean;
-}>`
-  ${({ theme, error, disabled }) => css`
-    width: 280px;
-    height: 32px;
+export const Container = styled(Box)`
+  ${() => css`
+    width: fit-content;
     border-radius: 4px;
-    display: flex;
-    border: 1px solid ${theme.colors.N400};
-    cursor: pointer;
-    column-gap: 12px;
-    background-color: ${theme.colors.N0};
-    ${error &&
-    css`
-      border-color: ${theme.colors.R400};
-    `}
-    ${disabled &&
-    css`
-      cursor: default;
-      border-color: ${theme.colors.N300};
-      background-color: ${theme.colors.N100};
-    `}
   `}
 `;
 
-export const TextWrapper = styled.div`
-  ${({ theme }) => css`
-    flex: 1;
-    height: 100%;
-    padding: 8px 12px;
-    white-space: nowrap;
-    overflow-x: auto;
-    overflow-y: none;
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
-    &::-webkit-scrollbar {
-      display: none; /* Chrome, Safari, Opera*/
+export const FilePickerInput = styled(Box)<{ focused: boolean }>`
+  ${({ focused }) => css`
+    & input {
+      max-width: 100%;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+    & div#parte-text-input-wrapper {
+      border-top-right-radius: 0px;
+      border-bottom-right-radius: 0px;
+      ${focused &&
+      css`
+        z-index: 2;
+      `}
     }
   `}
 `;
 
-export const Button = styled.div<{
-  hover: boolean;
-  focused: boolean;
-  error: boolean;
-  disabled: boolean;
-}>`
-  ${({ theme, hover, focused, error, disabled }) => css`
-    background-color: unset;
-    box-sizing: border-box;
-    padding: 8px 16px;
-    border: 1px solid ${theme.colors.N400};
-    border-radius: 4px;
-    height: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: ${theme.colors.N0};
-    margin: -1px;
-    ${!disabled &&
-    hover &&
-    css`
-      border-color: ${theme.colors.N600};
-    `}
-    ${!disabled &&
-    focused &&
-    css`
-      border-color: ${theme.colors.N500};
-      ${theme.commonStyles.outline}
-    `}
-    ${error &&
-    css`
-      border-color: ${theme.colors.R400};
-    `}
-    ${disabled &&
-    css`
-      border-color: ${theme.colors.N300};
-      background-color: ${theme.colors.N0};
-    `}
+export const FilePickerButton = styled(Button)`
+  ${({ theme }) => css`
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+    margin-left: -1px;
+    z-index: 1;
+    ${theme.typography.C200};
   `}
 `;
-
-export const ButtonText = styled.span<{
-  hover: boolean;
-  focused: boolean;
-  error: boolean;
-  disabled: boolean;
-}>`
-  ${({ theme, hover, focused, error, disabled }) => css`
-    ${Typography.C200}
-    color: ${theme.colors.N700};
-    ${(hover || focused) &&
-    css`
-      color: ${theme.colors.N800};
-    `}
-    ${error &&
-    css`
-      color: ${theme.colors.R400};
-    `}
-    ${disabled &&
-    css`
-      color: ${theme.colors.N500};
-    `}
-  `}
-`;
-
-export const ErrorText = styled.span<{
-  hover: boolean;
-  focused: boolean;
-  error: boolean;
-  disabled: boolean;
-}>``;
 
 export const LabelWrapper = styled.div`
   ${({ theme }) => css`

--- a/src/FilePicker/FilePicker.styled.ts
+++ b/src/FilePicker/FilePicker.styled.ts
@@ -1,0 +1,132 @@
+import styled, { css } from 'styled-components';
+import Typography from '../@foundations/Typography/typography';
+import { Box } from '../Layout';
+
+export const Container = styled(Box)<{
+  error: boolean;
+  disabled: boolean;
+}>`
+  ${({ theme, error, disabled }) => css`
+    width: 280px;
+    height: 32px;
+    border-radius: 4px;
+    display: flex;
+    border: 1px solid ${theme.colors.N400};
+    cursor: pointer;
+    column-gap: 12px;
+    background-color: ${theme.colors.N0};
+    ${error &&
+    css`
+      border-color: ${theme.colors.R400};
+    `}
+    ${disabled &&
+    css`
+      cursor: default;
+      border-color: ${theme.colors.N300};
+      background-color: ${theme.colors.N100};
+    `}
+  `}
+`;
+
+export const TextWrapper = styled.div`
+  ${({ theme }) => css`
+    flex: 1;
+    height: 100%;
+    padding: 8px 12px;
+    white-space: nowrap;
+    overflow-x: auto;
+    overflow-y: none;
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+    &::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera*/
+    }
+  `}
+`;
+
+export const Button = styled.div<{
+  hover: boolean;
+  focused: boolean;
+  error: boolean;
+  disabled: boolean;
+}>`
+  ${({ theme, hover, focused, error, disabled }) => css`
+    background-color: unset;
+    box-sizing: border-box;
+    padding: 8px 16px;
+    border: 1px solid ${theme.colors.N400};
+    border-radius: 4px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: ${theme.colors.N0};
+    margin: -1px;
+    ${!disabled &&
+    hover &&
+    css`
+      border-color: ${theme.colors.N600};
+    `}
+    ${!disabled &&
+    focused &&
+    css`
+      border-color: ${theme.colors.N500};
+      ${theme.commonStyles.outline}
+    `}
+    ${error &&
+    css`
+      border-color: ${theme.colors.R400};
+    `}
+    ${disabled &&
+    css`
+      border-color: ${theme.colors.N300};
+      background-color: ${theme.colors.N0};
+    `}
+  `}
+`;
+
+export const ButtonText = styled.span<{
+  hover: boolean;
+  focused: boolean;
+  error: boolean;
+  disabled: boolean;
+}>`
+  ${({ theme, hover, focused, error, disabled }) => css`
+    ${Typography.C200}
+    color: ${theme.colors.N700};
+    ${(hover || focused) &&
+    css`
+      color: ${theme.colors.N800};
+    `}
+    ${error &&
+    css`
+      color: ${theme.colors.R400};
+    `}
+    ${disabled &&
+    css`
+      color: ${theme.colors.N500};
+    `}
+  `}
+`;
+
+export const ErrorText = styled.span<{
+  hover: boolean;
+  focused: boolean;
+  error: boolean;
+  disabled: boolean;
+}>``;
+
+export const LabelWrapper = styled.div`
+  ${({ theme }) => css`
+    display: flex;
+    align-items: flex-start;
+    column-gap: ${theme.spacing.spacing2}px;
+  `}
+`;
+
+export const Label = styled.label`
+  ${({ theme }) => css`
+    ${theme.typography.H400}
+    color: ${theme.colorHeading};
+  `}
+`;

--- a/src/FilePicker/FilePicker.tsx
+++ b/src/FilePicker/FilePicker.tsx
@@ -1,0 +1,181 @@
+import { FilePickerProps } from './FilePicker.types';
+import * as Styled from './FilePicker.styled';
+import { ChangeEvent, useCallback, useRef, useState } from 'react';
+import { Caption, Paragraph } from '../@foundations/Typography';
+import { Box } from '../Layout';
+
+const defaultButtonText = (files: File[]) => {
+  const fileCount = files.length;
+  const action = fileCount === 0 ? 'Select' : 'Replace';
+  const fileLabel = fileCount > 1 ? 'files' : 'file';
+
+  return `${action} ${fileLabel}`;
+};
+
+const getInputValue = (files: File[]) => {
+  if (files.length === 1) {
+    return files[0].name;
+  }
+
+  if (files.length > 1) {
+    return `${files.length} files`;
+  }
+
+  return '';
+};
+
+const FilePicker = ({
+  label,
+  description,
+  required = false,
+  placeholder = 'Select the file here!',
+  name,
+  disabled = false,
+  multiple,
+  accept,
+  errorMessage,
+  buttonText = defaultButtonText,
+  inputText = getInputValue,
+  onBlur,
+  onChange,
+  // FIXME: 지우기
+  occurError,
+}: FilePickerProps) => {
+  const [files, setFiles] = useState<File[]>([]);
+  const [hover, setHover] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback(
+    (e: ChangeEvent) => {
+      setError(false);
+      if (occurError) {
+        setError(true);
+        return;
+      }
+      // Firefox returns the same array instance each time for some reason
+      const filesCopy = [...((e.target as HTMLInputElement)?.files ?? [])];
+
+      setFiles(filesCopy);
+      onChange?.(filesCopy);
+    },
+    [onChange]
+  );
+
+  const handleButtonClick = useCallback(() => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  }, []);
+
+  const handleBlur = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      // Setting e.target.files to an array fails. It must be a FileList
+      if (e.target) {
+        e.target.files = fileInputRef.current && fileInputRef.current.files;
+      }
+
+      onBlur?.(e);
+    },
+    [onBlur]
+  );
+
+  return (
+    <Box direction="column">
+      {(label || description) && (
+        <Box direction="column" gap={4} style={{ marginBottom: '8px' }}>
+          {label && (
+            <Styled.LabelWrapper>
+              {required && (
+                <Caption size={200} color="R400">
+                  *
+                </Caption>
+              )}
+              <Styled.Label
+                htmlFor={name}
+                title={required ? 'This field is required' : ''}
+              >
+                {label}
+              </Styled.Label>
+            </Styled.LabelWrapper>
+          )}
+          {description && (
+            <Paragraph size={100} color="N700">
+              {description}
+            </Paragraph>
+          )}
+        </Box>
+      )}
+      <Styled.Container
+        error={error}
+        disabled={disabled}
+        onMouseEnter={(e) => {
+          setHover(true);
+        }}
+        onMouseLeave={(e) => {
+          setHover(false);
+        }}
+        onMouseDown={(e) => {
+          setFocused(true);
+        }}
+        onMouseUp={(e) => {
+          setFocused(false);
+        }}
+        onBlurCapture={(e) => {
+          e.stopPropagation();
+        }}
+        onClick={handleButtonClick}
+      >
+        <input
+          style={{
+            position: 'absolute',
+            width: 0,
+            height: 0,
+            padding: 0,
+            overflow: 'hidden',
+            border: 0,
+          }}
+          ref={fileInputRef}
+          type="file"
+          name={name}
+          id={name}
+          accept={accept}
+          required={required}
+          multiple={multiple}
+          disabled={disabled}
+          onChange={handleFileChange}
+          onBlur={handleBlur}
+        />
+        <Styled.TextWrapper>
+          <Paragraph size={100} color={files.length ? 'N800' : 'N600'}>
+            {files.length ? inputText(files) : placeholder}
+          </Paragraph>
+        </Styled.TextWrapper>
+        <Styled.Button
+          hover={hover}
+          focused={focused}
+          error={error}
+          disabled={disabled}
+        >
+          <Styled.ButtonText
+            hover={hover}
+            focused={focused}
+            disabled={disabled}
+            error={error}
+          >
+            {buttonText(files)}
+          </Styled.ButtonText>
+        </Styled.Button>
+      </Styled.Container>
+      {error && errorMessage && (
+        <Paragraph size={100} color="R400" marginTop={2}>
+          error text
+        </Paragraph>
+      )}
+    </Box>
+  );
+};
+
+export default FilePicker;

--- a/src/FilePicker/FilePicker.tsx
+++ b/src/FilePicker/FilePicker.tsx
@@ -138,6 +138,7 @@ const FilePicker = ({
         <Styled.FilePickerButton
           variant="secondary"
           disabled={disabled}
+          error={!!errorMessage}
           onClick={handleButtonClick}
         >
           {buttonText(files)}

--- a/src/FilePicker/FilePicker.tsx
+++ b/src/FilePicker/FilePicker.tsx
@@ -1,8 +1,9 @@
 import { FilePickerProps } from './FilePicker.types';
 import * as Styled from './FilePicker.styled';
 import { ChangeEvent, useCallback, useRef, useState } from 'react';
-import { Caption, Paragraph } from '../@foundations/Typography';
 import { Box } from '../Layout';
+import { Caption, Paragraph } from '../@foundations/Typography';
+import TextInput from '../TextInput';
 
 const defaultButtonText = (files: File[]) => {
   const fileCount = files.length;
@@ -34,27 +35,20 @@ const FilePicker = ({
   multiple,
   accept,
   errorMessage,
-  buttonText = defaultButtonText,
   inputText = getInputValue,
+  buttonText = defaultButtonText,
   onBlur,
   onChange,
-  // FIXME: 지우기
-  occurError,
 }: FilePickerProps) => {
   const [files, setFiles] = useState<File[]>([]);
-  const [hover, setHover] = useState(false);
-  const [focused, setFocused] = useState(false);
-  const [error, setError] = useState(false);
-
+  const [inputFocused, setInputFocused] = useState(false);
+  // textInput 컴포넌트를 참조
+  const inputRef = useRef<HTMLInputElement>(null);
+  // file picker의 역할을하는 input엘리먼트를 참조
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = useCallback(
     (e: ChangeEvent) => {
-      setError(false);
-      if (occurError) {
-        setError(true);
-        return;
-      }
       // Firefox returns the same array instance each time for some reason
       const filesCopy = [...((e.target as HTMLInputElement)?.files ?? [])];
 
@@ -108,26 +102,7 @@ const FilePicker = ({
           )}
         </Box>
       )}
-      <Styled.Container
-        error={error}
-        disabled={disabled}
-        onMouseEnter={(e) => {
-          setHover(true);
-        }}
-        onMouseLeave={(e) => {
-          setHover(false);
-        }}
-        onMouseDown={(e) => {
-          setFocused(true);
-        }}
-        onMouseUp={(e) => {
-          setFocused(false);
-        }}
-        onBlurCapture={(e) => {
-          e.stopPropagation();
-        }}
-        onClick={handleButtonClick}
-      >
+      <Styled.Container>
         <input
           style={{
             position: 'absolute',
@@ -148,32 +123,26 @@ const FilePicker = ({
           onChange={handleFileChange}
           onBlur={handleBlur}
         />
-        <Styled.TextWrapper>
-          <Paragraph size={100} color={files.length ? 'N800' : 'N600'}>
-            {files.length ? inputText(files) : placeholder}
-          </Paragraph>
-        </Styled.TextWrapper>
-        <Styled.Button
-          hover={hover}
-          focused={focused}
-          error={error}
-          disabled={disabled}
-        >
-          <Styled.ButtonText
-            hover={hover}
-            focused={focused}
+        <Styled.FilePickerInput focused={inputFocused}>
+          <TextInput
             disabled={disabled}
-            error={error}
-          >
-            {buttonText(files)}
-          </Styled.ButtonText>
-        </Styled.Button>
+            ref={inputRef}
+            onFocus={() => setInputFocused(true)}
+            onBlur={() => setInputFocused(false)}
+            fullWidth
+            errorText={errorMessage}
+            placeholder={placeholder}
+            value={inputText(files)}
+          />
+        </Styled.FilePickerInput>
+        <Styled.FilePickerButton
+          variant="secondary"
+          disabled={disabled}
+          onClick={handleButtonClick}
+        >
+          {buttonText(files)}
+        </Styled.FilePickerButton>
       </Styled.Container>
-      {error && errorMessage && (
-        <Paragraph size={100} color="R400" marginTop={2}>
-          error text
-        </Paragraph>
-      )}
     </Box>
   );
 };

--- a/src/FilePicker/FilePicker.types.ts
+++ b/src/FilePicker/FilePicker.types.ts
@@ -1,0 +1,20 @@
+import { ChangeEvent, HTMLAttributes } from 'react';
+
+export type FilePickerProps = HTMLAttributes<HTMLInputElement> & {
+  name: string;
+  placeholder?: string;
+  accept?: string;
+  disabled?: boolean;
+  multiple?: boolean;
+  required?: boolean;
+  errorMessage?: string;
+  label?: string;
+  description?: string;
+  onChange?: (files: File[]) => void;
+  onBlur?: (event: ChangeEvent<HTMLInputElement>) => void;
+  inputText?: (files: File[]) => string;
+  buttonText?: (files: File[]) => string;
+
+  // FIXME: 창희님 테스트를 위해 잠시 설정해놓는 props
+  occurError?: boolean;
+};

--- a/src/FilePicker/FilePicker.types.ts
+++ b/src/FilePicker/FilePicker.types.ts
@@ -14,7 +14,4 @@ export type FilePickerProps = HTMLAttributes<HTMLInputElement> & {
   onBlur?: (event: ChangeEvent<HTMLInputElement>) => void;
   inputText?: (files: File[]) => string;
   buttonText?: (files: File[]) => string;
-
-  // FIXME: 창희님 테스트를 위해 잠시 설정해놓는 props
-  occurError?: boolean;
 };

--- a/src/FilePicker/index.ts
+++ b/src/FilePicker/index.ts
@@ -1,0 +1,1 @@
+export { default as FilePicker } from './FilePicker';

--- a/src/Overlay/Overlay.stories.tsx
+++ b/src/Overlay/Overlay.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/react';
 import { useState } from 'react';
-import { Button } from '../Button';
+import Button from '../Button';
 import Overlay from './Overlay';
 import { OverlayProps } from './Overlay.types';
 

--- a/src/SideSheet/SideSheet.stories.tsx
+++ b/src/SideSheet/SideSheet.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from '@storybook/react';
 import { useState } from 'react';
-import { Button } from '../Button';
+import Button from '../Button';
 import { Tab } from '../Tabs/Tab';
 import { Tabs } from '../Tabs';
 import SideSheet from './SideSheet';

--- a/src/TextInput/TextInput.styled.ts
+++ b/src/TextInput/TextInput.styled.ts
@@ -16,20 +16,23 @@ export const InputWrapper = styled.div<{
   disabled?: boolean;
   hover?: boolean;
   fullWidth?: boolean;
+  readOnly?: boolean;
 }>`
-  ${({ theme, focused, disabled, error, hover, fullWidth }) => css`
+  ${({ theme, focused, disabled, error, hover, fullWidth, readOnly }) => css`
     box-sizing: border-box;
     display: inline-flex;
     overflow: hidden;
     border: 1px solid ${theme.colorBorderDefault};
     border-radius: 4px;
     width: ${fullWidth ? '100%' : 'fit-content'};
-    ${hover &&
+    ${!readOnly &&
+    hover &&
     css`
       border: 1px solid ${theme.colorBorderHover};
       background: ${theme.colorBackgroundHover};
     `}
-    ${focused &&
+    ${!readOnly &&
+    focused &&
     css`
        {
         border: 1px solid ${theme.colorBorderFocused};
@@ -145,16 +148,18 @@ export const Input = styled.input<TextInputProps>`
     ::placeholder {
       color: ${theme.colorTextPlaceholderDefault};
     }
-
-    &:hover {
+    &:not(:read-only):hover {
       ::placeholder {
         color: ${theme.colorTextPlaceholderHover};
       }
     }
-    &:focus {
+    &:not(:read-only):focus {
       ::placeholder {
         color: ${theme.colorTextPlaceholderFocused};
       }
+    }
+    &:read-only {
+      cursor: default;
     }
     &:disabled {
       color: ${theme.colorTextDisabled};

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -44,6 +44,7 @@ const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           error={!!errorText}
           onMouseEnter={() => setHover(true)}
           onMouseLeave={() => setHover(false)}
+          id="parte-text-input-wrapper"
         >
           {leadingIcon && (
             <Styled.LeftIconContainer disabled={props.disabled}>

--- a/src/TextInput/index.ts
+++ b/src/TextInput/index.ts
@@ -1,1 +1,1 @@
-export { default as TextInput } from './TextInput';
+export { default } from './TextInput';

--- a/src/Toaster/Toaster.stories.tsx
+++ b/src/Toaster/Toaster.stories.tsx
@@ -2,7 +2,7 @@ import { Story, Meta } from '@storybook/react';
 import toaster from '.';
 import { Alert } from '../Alerts';
 import { AlertProps } from '../Alerts/Alert.types';
-import { Button } from '../Button';
+import Button from '../Button';
 
 export default {
   title: 'Components/Alerts/Toaster',

--- a/src/common/styleReset.ts
+++ b/src/common/styleReset.ts
@@ -144,17 +144,14 @@ export default css`
   input,
   textarea,
   button,
+  code,
   body {
-    font-family: 'Pretendard Variable', Pretendard, -apple-system,
+    font-family: Pretendard Variable, Pretendard, -apple-system,
       BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
       'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
       'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
   }
 
-  code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-      monospace;
-  }
   input[type='number']::-webkit-outer-spin-button,
   input[type='number']::-webkit-inner-spin-button {
     -webkit-appearance: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,16 +1365,15 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@joshwooding/vite-plugin-react-docgen-typescript@0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.0.5.tgz#67f6a6e0b532febdd04cf809b3d4ce2fd593e1a5"
-  integrity sha512-HwAEj/vAP1+hzBfIv9DTCyg+1O0/LG48Up7j1RmJ+pFwjb/wRxzUBco4LqKFKe7SZ0M6IyASNh1oKP3yHnJElA==
+"@joshwooding/vite-plugin-react-docgen-typescript@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.2.1.tgz#930f6f0382520e4ba349eea1b152f9ae49364516"
+  integrity sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==
   dependencies:
-    "@rollup/pluginutils" "^4.2.1"
     glob "^7.2.0"
     glob-promise "^4.2.0"
-    magic-string "^0.26.1"
-    react-docgen-typescript "^2.1.1"
+    magic-string "^0.27.0"
+    react-docgen-typescript "^2.2.2"
 
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
@@ -1411,7 +1410,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -1584,14 +1583,6 @@
     is-builtin-module "^3.2.0"
     is-module "^1.0.0"
     resolve "^1.22.1"
-
-"@rollup/pluginutils@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
-  integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
-  dependencies:
-    estree-walker "^2.0.1"
-    picomatch "^2.2.2"
 
 "@rollup/pluginutils@^5.0.1":
   version "5.0.2"
@@ -1935,24 +1926,23 @@
     ts-dedent "^2.0.0"
     util-deprecate "^1.0.2"
 
-"@storybook/builder-vite@^0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@storybook/builder-vite/-/builder-vite-0.2.5.tgz#b3996a5f28ffd1ce2ca18aff98cf3ed9d4551927"
-  integrity sha512-0PktEaYsbR6gGE/YDkW/tI1VxVnaPNZpHGpiWfDU7c5hjCajWYzdFTgHOwcXT8tiTs+WN/rvoCPT2iAhSCcHIw==
+"@storybook/builder-vite@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@storybook/builder-vite/-/builder-vite-0.4.2.tgz#e4524da1d9fd141ebde3a10cac6c1214de6856eb"
+  integrity sha512-KBBiDdYCK0BCOns8iCVrtzaIiYQF9NjwQ7u3HY/a0bmAuaXPd9m3t6Tvp2jNwmdRAtHOHXnM+d6ROJAI77DCYg==
   dependencies:
-    "@joshwooding/vite-plugin-react-docgen-typescript" "0.0.5"
+    "@joshwooding/vite-plugin-react-docgen-typescript" "0.2.1"
     "@storybook/core-common" "^6.4.3"
-    "@storybook/mdx1-csf" "^0.0.4"
+    "@storybook/mdx1-csf" "1.0.0-next.0"
     "@storybook/node-logger" "^6.4.3"
     "@storybook/semver" "^7.3.2"
     "@storybook/source-loader" "^6.4.3"
-    "@vitejs/plugin-react" "^2.0.0"
     ast-types "^0.14.2"
     es-module-lexer "^0.9.3"
     glob "^7.2.0"
     glob-promise "^4.2.0"
     magic-string "^0.26.1"
-    react-docgen "^6.0.0-alpha.0"
+    react-docgen "6.0.0-alpha.3"
     slash "^3.0.0"
     sveltedoc-parser "^4.2.1"
 
@@ -2475,6 +2465,14 @@
     webpack-dev-middleware "^3.7.3"
     webpack-virtual-modules "^0.2.2"
 
+"@storybook/mdx1-csf@1.0.0-next.0":
+  version "1.0.0-next.0"
+  resolved "https://registry.yarnpkg.com/@storybook/mdx1-csf/-/mdx1-csf-1.0.0-next.0.tgz#6745d974037f5c2d3e1cd38f285d92919e69fda5"
+  integrity sha512-zrv5yRKSOQum69DU+5+wK1VcfmHv8xdqLsACeVOHJp1Mq2eG8s3/WuEA0L3wljoebbuKasZecn2Eu/TQCt+0og==
+  dependencies:
+    "@mdx-js/mdx" "^1.6.22"
+    "@mdx-js/react" "^1.6.22"
+
 "@storybook/mdx1-csf@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@storybook/mdx1-csf/-/mdx1-csf-0.0.1.tgz#d4184e3f6486fade9f7a6bfaf934d9bc07718d5b"
@@ -2485,24 +2483,6 @@
     "@babel/preset-env" "^7.12.11"
     "@babel/types" "^7.12.11"
     "@mdx-js/mdx" "^1.6.22"
-    "@types/lodash" "^4.14.167"
-    js-string-escape "^1.0.1"
-    loader-utils "^2.0.0"
-    lodash "^4.17.21"
-    prettier ">=2.2.1 <=2.3.0"
-    ts-dedent "^2.0.0"
-
-"@storybook/mdx1-csf@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@storybook/mdx1-csf/-/mdx1-csf-0.0.4.tgz#02b1b3f34b476de90fc034948029dd46d16cf755"
-  integrity sha512-xxUEMy0D+0G1aSYxbeVNbs+XBU5nCqW4I7awpBYSTywXDv/MJWeC6FDRpj5P1pgfq8j8jWDD5ZDvBQ7syFg0LQ==
-  dependencies:
-    "@babel/generator" "^7.12.11"
-    "@babel/parser" "^7.12.11"
-    "@babel/preset-env" "^7.12.11"
-    "@babel/types" "^7.12.11"
-    "@mdx-js/mdx" "^1.6.22"
-    "@mdx-js/react" "^1.6.22"
     "@types/lodash" "^4.14.167"
     js-string-escape "^1.0.1"
     loader-utils "^2.0.0"
@@ -3299,7 +3279,7 @@
     tslib "^1.9.0"
     typescript "^3.1.3"
 
-"@vitejs/plugin-react@^2.0.0", "@vitejs/plugin-react@^2.2.0":
+"@vitejs/plugin-react@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-2.2.0.tgz#1b9f63b8b6bc3f56258d20cd19b33f5cc761ce6e"
   integrity sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==
@@ -6299,7 +6279,7 @@ estree-to-babel@^3.1.0:
     "@babel/types" "^7.2.0"
     c8 "^7.6.0"
 
-estree-walker@^2.0.1, estree-walker@^2.0.2:
+estree-walker@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
@@ -8705,6 +8685,13 @@ magic-string@^0.26.1, magic-string@^0.26.7:
   dependencies:
     sourcemap-codec "^1.4.8"
 
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -9914,7 +9901,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.0, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.0, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -10367,10 +10354,26 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-docgen-typescript@^2.1.1:
+react-docgen-typescript@^2.1.1, react-docgen-typescript@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz#4611055e569edc071204aadb20e1c93e1ab1659c"
   integrity sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==
+
+react-docgen@6.0.0-alpha.3:
+  version "6.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-6.0.0-alpha.3.tgz#4d8a4916b45de4aadb90eb5f3a6f923edf447928"
+  integrity sha512-DDLvB5EV9As1/zoUsct6Iz2Cupw9FObEGD3DMcIs3EDFIoSKyz8FZtoWj3Wj+oodrU4/NfidN0BL5yrapIcTSA==
+  dependencies:
+    "@babel/core" "^7.7.5"
+    "@babel/generator" "^7.12.11"
+    ast-types "^0.14.2"
+    commander "^2.19.0"
+    doctrine "^3.0.0"
+    estree-to-babel "^3.1.0"
+    neo-async "^2.6.1"
+    node-dir "^0.1.10"
+    resolve "^1.17.0"
+    strip-indent "^3.0.0"
 
 react-docgen@^4.1.0:
   version "4.1.1"
@@ -10399,22 +10402,6 @@ react-docgen@^5.0.0:
     estree-to-babel "^3.1.0"
     neo-async "^2.6.1"
     node-dir "^0.1.10"
-    strip-indent "^3.0.0"
-
-react-docgen@^6.0.0-alpha.0:
-  version "6.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-6.0.0-alpha.3.tgz#4d8a4916b45de4aadb90eb5f3a6f923edf447928"
-  integrity sha512-DDLvB5EV9As1/zoUsct6Iz2Cupw9FObEGD3DMcIs3EDFIoSKyz8FZtoWj3Wj+oodrU4/NfidN0BL5yrapIcTSA==
-  dependencies:
-    "@babel/core" "^7.7.5"
-    "@babel/generator" "^7.12.11"
-    ast-types "^0.14.2"
-    commander "^2.19.0"
-    doctrine "^3.0.0"
-    estree-to-babel "^3.1.0"
-    neo-async "^2.6.1"
-    node-dir "^0.1.10"
-    resolve "^1.17.0"
     strip-indent "^3.0.0"
 
 react-dom@^18.2.0:


### PR DESCRIPTION
# 고민
influencer때를 생각해보면,
file을 선택할때, 
1. file upload
2. 그 file을 aws로 보냄
  2-1. file을 받는동안 loading을 보여줌
3. file의 path를 받음
  3-1. 성공
  3-2. 실패시 error보여줌

이런 흐름이었자나용
위 같은 경우는 엄청 custom하게 사용이되었었는데,

그런데 design system FilePicker의 역할을 생각해보면
1. file upload
2. `File`타입의 데이터를 onChange로 넘겨줌

이게 다라
비동기 관련된 처리를 filePicker자체에서 처리를 해줄필요가없어요!

피그마에는 upload와 관련된 디자인이있지만,
제가 생각했을땐, 이 상태들을 처리해줄필요가있을까 고민이드네용!

의견 구다사이~

# 제목
Forms > FilePicker

## 내용
evergreen과 스타일이 달라, evergreen의 컴포넌트와 레이아웃구조가 다릅니다.
로직은 같아요!

## 설계
Input + Button의 조합으로 구성하려했으나, 디자인이슈로 div로 구성했습니다!

## 디자인
실제 파일을 업로드해보시면서 테스트해보시면됩니다.
@seocharmings 님, 제가 버튼의 스타일을 변경해서, 지금 버튼을 사용한 다른 디자인들도 영향을 받았기때문에, 파일 변경사항이 많다고 나오고있습니다.
버튼의 기본 font-weight가 500으로 적용되어있길래 그 값을 지워줬고, box-sizing도 추가를하니깐 사이즈가 조금 달라졌습니다.
혹시 이부분에 대해서 의견있으시면 크로매틱에 남겨주세요

## 기타
