### PR TITLE
Link Component

### DIFF
--- a/src/@foundations/Typography/typography.types.ts
+++ b/src/@foundations/Typography/typography.types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { CSSProperties } from 'styled-components';
 import { Colors } from '../Colors/colors.types';
 import typography from './typography';
@@ -10,7 +11,7 @@ export type CommonProps = {
   marginBottom?: number;
   marginLeft?: number;
   marginRight?: number;
-  children: string;
+  children: ReactNode;
   overrideStyles?: CSSProperties;
   color?: keyof Colors;
 };

--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -1,0 +1,54 @@
+import { Meta, Story } from '@storybook/react';
+import { Paragraph } from '../@foundations/Typography';
+import { Box } from '../Layout';
+import Link from './Link';
+import { LinkProps } from './Link.types';
+
+export default {
+  title: 'Components/Buttons/Link',
+  component: Link,
+  parameters: {
+    layout: 'centered',
+    viewport: 'responsive',
+  },
+} as Meta;
+
+const Template: Story<LinkProps> = ({ children, ...args }) => {
+  return (
+    <Box>
+      <Link {...args}>{children}</Link>
+    </Box>
+  );
+};
+const LinkInParagraphTemplate: Story<LinkProps> = ({ children, ...args }) => {
+  return (
+    <Box>
+      <Paragraph size={200}>
+        <>
+          {`Hello! It's a `}
+          <Link {...args}>{children}</Link> {`Component`}
+        </>
+      </Paragraph>
+    </Box>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  children: 'Link',
+  href: 'https://google.com',
+  target: '_blank',
+};
+export const LinkInParagraph = LinkInParagraphTemplate.bind({});
+LinkInParagraph.args = {
+  children: 'Link',
+  href: 'https://google.com',
+  target: '_blank',
+};
+export const Disabled = Template.bind({});
+Disabled.args = {
+  children: 'Disabled Link',
+  href: 'https://google.com',
+  disabled: true,
+  target: '_blank',
+};

--- a/src/Link/Link.styled.ts
+++ b/src/Link/Link.styled.ts
@@ -1,0 +1,48 @@
+import styled, { css } from 'styled-components';
+import { LinkProps } from './Link.types';
+
+export const Link = styled.a<LinkProps>`
+  ${({ theme, size = 400 }) => {
+    let typo;
+    switch (size) {
+      case 500:
+        typo = theme.typography.H500;
+        break;
+      case 300:
+        typo = theme.typography.H300;
+        break;
+      case 400:
+      default:
+        typo = theme.typography.H400;
+        break;
+    }
+    return css`
+      color: ${theme.colorTextLink};
+      ${typo}
+      cursor: pointer;
+
+      &:hover {
+        color: ${theme.colorTextLinkHover};
+      }
+      &:active {
+        color: ${theme.colorTextLinkPressed};
+      }
+      &:focus {
+        color: ${theme.colorTextLinkFocused};
+        ${theme.commonStyles.outline};
+        border-radius: ${theme.spacing.spacing4}px;
+      }
+      &:visited {
+        color: ${theme.colorTextLinkVisited};
+      }
+    `;
+  }}
+`;
+
+export const DisabledLink = styled.span`
+  ${({ theme }) => css`
+    ${theme.typography.H400};
+    color: ${theme.colorTextLinkDisabled};
+    cursor: default;
+  `}
+`;

--- a/src/Link/Link.tsx
+++ b/src/Link/Link.tsx
@@ -1,0 +1,11 @@
+import * as Styled from './Link.styled';
+import { LinkProps } from './Link.types';
+
+const Link = ({ disabled, children, ...props }: LinkProps) => {
+  return disabled ? (
+    <Styled.DisabledLink>{children}</Styled.DisabledLink>
+  ) : (
+    <Styled.Link {...props}>{children}</Styled.Link>
+  );
+};
+export default Link;

--- a/src/Link/Link.types.ts
+++ b/src/Link/Link.types.ts
@@ -1,0 +1,6 @@
+import { AnchorHTMLAttributes } from 'react';
+
+export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  disabled?: boolean;
+  size?: 300 | 400 | 500;
+};

--- a/src/Link/index.tsx
+++ b/src/Link/index.tsx
@@ -1,0 +1,1 @@
+export { default as Link } from './Link';

--- a/src/common/theme/colorToken/index.ts
+++ b/src/common/theme/colorToken/index.ts
@@ -4,6 +4,7 @@ import { default as formToken } from './form';
 import { default as generalToken } from './general';
 import { default as dropdownToken } from './dropdown';
 import { default as overlayToken } from './overlay';
+import { default as linkToken } from './link';
 
 export const tokens = {
   ...buttonColorToken,
@@ -12,5 +13,6 @@ export const tokens = {
   ...generalToken,
   ...dropdownToken,
   ...overlayToken,
+  ...linkToken,
 };
 export type TokenType = typeof tokens;

--- a/src/common/theme/colorToken/link.ts
+++ b/src/common/theme/colorToken/link.ts
@@ -1,0 +1,14 @@
+import { COLORS } from '../../../@foundations/Colors';
+
+const LinkToken = {
+  colorTextLink: COLORS.B400,
+  colorTextLinkHover: COLORS.B500,
+  colorTextLinkPressed: COLORS.B600,
+  colorTextLinkFocused: COLORS.B500,
+  colorTextLinkDisabled: COLORS.N500,
+  colorTextLinkVisited: COLORS.V400,
+} as const;
+
+export default {
+  ...LinkToken,
+};


### PR DESCRIPTION
## 내용
- Typography 컴포넌트의 children을 `string` -> `ReactNode`으로 변경
- Link 컴포넌트의 사이즈는 300, 400(Default), 500 (에버그린 참조함)
- a 태그 에는 `disabled` attribute가 애초에 존재하지 않음, disabled 기능을 구현하려면 onClick을 막는 등의 몇가지 방법이 있지만 그냥 깔끔하게 disabled 일 경우에는 span 태그로 변경되도록 변경

## 설계
Link도 Typography의 자식이 충분히 될 수 있다고 생각해서 스토리북 예시도 그렇게 만들었고
Typography의 children도 ReactNode로 변경했습니다. 
Typography에서 children에 그럼 div가 오면 어쩌냐~~ 이럴수도 있지만 그건 그냥 개발자 잘못인걸로 하는게 맞는것 같아요
웹 개발자라면 웹 표준을 지켜야죠!!