### PR TITLE
:bug: Dropdown에서 Portal 사용시 outside 판정 이슈

### DIFF
--- a/src/Dropdown/Dropdown.stories.tsx
+++ b/src/Dropdown/Dropdown.stories.tsx
@@ -1,10 +1,10 @@
-import { Story, Meta } from '@storybook/react';
-import { Button } from '../Button';
-import Dropdown from './Dropdown';
-import { DropdownList } from './DropdownList';
-import { DropdownContextState } from './Dropdown.types';
+import { Meta, Story } from '@storybook/react';
 import { useState } from 'react';
+import { Button } from '../Button';
 import ActionChatIcon from '../parte-icons/Icons/ActionChatIcon';
+import Dropdown from './Dropdown';
+import { DropdownProps } from './Dropdown.types';
+import { DropdownList } from './DropdownList';
 
 const OPTIONS: Option<string>[] = [
   {
@@ -95,7 +95,7 @@ export default {
   },
 } as Meta;
 
-const Template: Story<DropdownContextState<string>> = ({ ...args }) => {
+const Template: Story<DropdownProps> = ({ ...args }) => {
   const [selectValue, setSelectValue] = useState<Option<string>>({
     label: 'label3',
     value: 'value3',
@@ -132,9 +132,10 @@ const Template: Story<DropdownContextState<string>> = ({ ...args }) => {
   );
 };
 
-const GroupedTemplate: Story<
-  DropdownContextState<string> & { isSearchable?: boolean }
-> = ({ isSearchable, ...args }) => {
+const GroupedTemplate: Story<DropdownProps & { isSearchable?: boolean }> = ({
+  isSearchable,
+  ...args
+}) => {
   const [selectValue, setSelectValue] = useState<Option<string>>();
 
   const onSelect = (value: Option<string>) => {
@@ -166,9 +167,10 @@ const GroupedTemplate: Story<
     </div>
   );
 };
-const MultiTemplate: Story<
-  DropdownContextState<string> & { closeOnSelect: boolean }
-> = ({ closeOnSelect, ...args }) => {
+const MultiTemplate: Story<DropdownProps & { closeOnSelect: boolean }> = ({
+  closeOnSelect,
+  ...args
+}) => {
   const [selectValue, setSelectValue] = useState<Option<string>[]>();
 
   return (

--- a/src/Dropdown/Dropdown.types.ts
+++ b/src/Dropdown/Dropdown.types.ts
@@ -3,15 +3,26 @@ import { RefObject, ReactNode } from 'react';
 export type GroupOption = {
   title: string;
 };
-export type DropdownContextState<T> = {
-  type?: 'single' | 'multi';
-  isOpen?: boolean;
-  value?: Option<T>;
-  onClick?: () => void;
-  // onClick?: React.MouseEventHandler<HTMLDivElement>;
-  onClose?: () => void;
-  usePortal?: boolean;
-  dropdownRef?: RefObject<HTMLDivElement>;
-  offset?: number;
+
+export interface DropdownProps {
   children?: ReactNode;
-};
+  usePortal?: boolean;
+  offset?: number;
+}
+
+export interface DropdownContextState extends DropdownProps {
+  isOpen: boolean;
+  onClick?: () => void;
+  onClose?: () => void;
+  dropdownRef?: RefObject<HTMLDivElement>;
+  menuRef?: React.RefObject<HTMLDivElement>;
+}
+
+export interface DropdownTriggerProps {
+  children: React.ReactNode;
+}
+export interface DropdownMenuProps {
+  children:
+    | React.ReactNode
+    | (({ onClose }: { onClose?: () => void }) => React.ReactNode);
+}

--- a/src/Dropdown/DropdownContext.ts
+++ b/src/Dropdown/DropdownContext.ts
@@ -1,6 +1,8 @@
 import { createContext } from 'react';
 import { DropdownContextState } from './Dropdown.types';
 
-const DropdownContext = createContext<DropdownContextState<unknown>>({});
+const DropdownContext = createContext<DropdownContextState>({
+  isOpen: false,
+});
 
 export default DropdownContext;

--- a/src/Dropdown/DropdownList/DropdownList.tsx
+++ b/src/Dropdown/DropdownList/DropdownList.tsx
@@ -48,6 +48,7 @@ const DropdownList = <T,>({
       if (!value) {
         onChange?.([option]);
       } else if (!('length' in value)) {
+        // eslint-disable-next-line no-console
         console.warn(
           'value props should be array type if you use isMulti option.'
         );


### PR DESCRIPTION
## 내용
>Dropdown 컴포넌트에서 usePortal로 `Menu`를 맨 상위로 빼내면 Dropdown의 child element가 아니게 된다.
그래서 메뉴를 클릭했음에도 outside 클릭 판정이 난다.

-> `menuRef`를 Dropdown 컴포넌트에서 선언해주고 useOusideClick 훅의 Refs에 전달하도록 변경하였다

> Dropdown의 Menu에서 DropdownList 컴포넌트가 아닌 다른 컴포넌트로 Menu를 구성하면 능동적으로 Dropdown을 close할 방법이 없다.

->  `Dropdown.Menu`의 children 요소를 그냥 ReactNode 혹은 onClose 를 받는 renderProps로 변경


