### PR TITLE
:bug: CornerDialog의 Container width 속성이 잘못됨

### DIFF
--- a/src/CornerDialog/CornerDialog.styled.ts
+++ b/src/CornerDialog/CornerDialog.styled.ts
@@ -29,6 +29,7 @@ export const DialogContainer = styled(Box)`
     position: fixed;
     bottom: 50px;
     right: 50px;
+    width: fit-content;
 
     &[data-state='entering'] {
       animation: ${openAnimation} ${ANIMATION_DURATION}ms ${spring} both;


### PR DESCRIPTION
- Corner Dialog가 위치가 이상하게 나오는 이슈
-> Container의 넓이가 `width: inherit;`으로 잡혀있어서 생긴 이슈

Layout 컴포넌트 잡으면서 Box를 다듬으면 해결될 이슈지만 일단 선제적으로 고쳐놓았습니다
