### PR TITLE
:wrench: src에 js 파일 안생기도록 수정

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "outDir": "dist"
   },
   "include": [".storybook/*", "**/*.ts", "**/*.tsx"],
   "exclude": ["**/tests", "**/*.test.ts"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,10 +13,10 @@ import dts from 'vite-plugin-dts';
 const extensions = ['.js', '.jsx', '.ts', '.tsx'];
 export default defineConfig({
   plugins: [
-    react(),
     dts({
       include: ['src/'],
     }),
+    react(),
   ],
   build: {
     lib: {


### PR DESCRIPTION
tsconfig파일에 `"outDir": "dist"`에 추가했더니 에러발생
> Module '"react/jsx-runtime"' has no exported member 'jsx'.

https://github.com/qmhc/vite-plugin-dts/issues/148
해당 이슈보고 해결